### PR TITLE
Forward list optimization

### DIFF
--- a/src/forward_list.c
+++ b/src/forward_list.c
@@ -179,15 +179,13 @@ int forward_list_add_at(forward_list me, const int index, void *const data)
     if (index == 0) {
         add->next = me->head;
         me->head = add;
-    } else if (index == me->item_count) {
-        struct node *const traverse = forward_list_get_node_at(me, index - 1);
-        add->next = traverse->next;
-        traverse->next = add;
-        me->tail = add;
     } else {
         struct node *const traverse = forward_list_get_node_at(me, index - 1);
         add->next = traverse->next;
         traverse->next = add;
+        if (!add->next) {
+            me->tail = add;
+        }
     }
     me->item_count++;
     return 0;
@@ -251,18 +249,15 @@ int forward_list_remove_at(forward_list me, const int index)
         me->head = temp->next;
         free(temp->data);
         free(temp);
-    } else if (index == me->item_count - 1) {
-        struct node *const traverse = forward_list_get_node_at(me, index - 1);
-        free(traverse->next->data);
-        free(traverse->next);
-        traverse->next = NULL;
-        me->tail = NULL;
     } else {
         struct node *const traverse = forward_list_get_node_at(me, index - 1);
         struct node *const backup = traverse->next;
         traverse->next = traverse->next->next;
         free(backup->data);
         free(backup);
+        if (!backup->next) {
+            me->tail = NULL;
+        }
     }
     me->item_count--;
     return 0;

--- a/src/list.c
+++ b/src/list.c
@@ -140,11 +140,10 @@ static struct node *list_get_node_from_tail(list me, const int index)
  */
 static struct node *list_get_node_at(list me, const int index)
 {
-    if (index <= me->item_count / 2) {
+    if (index < me->item_count / 2) {
         return list_get_node_from_head(me, index);
-    } else {
-        return list_get_node_from_tail(me, index);
     }
+    return list_get_node_from_tail(me, index);
 }
 
 /**

--- a/tst/forward_list.c
+++ b/tst/forward_list.c
@@ -150,6 +150,20 @@ static void test_basic(void)
     assert(!forward_list_destroy(me));
 }
 
+static void test_add_back(void)
+{
+    int i;
+    forward_list me = forward_list_init(sizeof(int));
+    assert(me);
+    for (i = 0; i < 10000; i++) {
+        int get = 0xdeadbeef;
+        forward_list_add_last(me, &i);
+        forward_list_get_last(&get, me);
+        assert(get == i);
+    }
+    assert(!forward_list_destroy(me));
+}
+
 static void test_init_out_of_memory(void)
 {
     fail_malloc = 1;
@@ -264,6 +278,7 @@ void test_forward_list(void)
 {
     test_invalid_init();
     test_basic();
+    test_add_back();
     test_init_out_of_memory();
     test_add_first_out_of_memory();
     test_add_at_out_of_memory();

--- a/tst/forward_list.c
+++ b/tst/forward_list.c
@@ -155,11 +155,16 @@ static void test_add_back(void)
     int i;
     forward_list me = forward_list_init(sizeof(int));
     assert(me);
-    for (i = 0; i < 10000; i++) {
+    for (i = 1; i < 10000; i++) {
         int get = 0xdeadbeef;
         forward_list_add_last(me, &i);
         forward_list_get_last(&get, me);
         assert(get == i);
+        if (i % 5 == 0) {
+            forward_list_remove_last(me);
+            forward_list_get_last(&get, me);
+            assert(get != i);
+        }
     }
     assert(!forward_list_destroy(me));
 }

--- a/tst/forward_list.c
+++ b/tst/forward_list.c
@@ -163,7 +163,7 @@ static void test_add_back(void)
         if (i % 5 == 0) {
             forward_list_remove_last(me);
             forward_list_get_last(&get, me);
-            assert(get != i);
+            assert(get == i - 1);
         }
     }
     assert(!forward_list_destroy(me));


### PR DESCRIPTION
Add a tail pointer which is either NULL or points to the back of the list. This improves the performance when adding to the back of the list many times in a row.