### PR TITLE
Reduce malloc calls

### DIFF
--- a/src/forward_list.c
+++ b/src/forward_list.c
@@ -238,6 +238,9 @@ int forward_list_remove_at(forward_list me, const size_t index)
     if (index == 0) {
         char *temp = me->head;
         memcpy(&me->head, temp + node_next_ptr_offset, sizeof(char *));
+        if (!me->head) {
+            me->tail = NULL;
+        }
         free(temp);
     } else {
         char *traverse = forward_list_get_node_at(me, index - 1);
@@ -408,6 +411,7 @@ void forward_list_clear(forward_list me)
         free(temp);
     }
     me->head = NULL;
+    me->tail = NULL;
     me->item_count = 0;
 }
 

--- a/src/forward_list.c
+++ b/src/forward_list.c
@@ -31,6 +31,7 @@ struct internal_forward_list {
     char *tail;
 };
 
+const size_t ptr_size = sizeof(char *);
 const size_t node_next_ptr_offset = 0;
 const size_t node_data_ptr_offset = sizeof(char *);
 
@@ -102,7 +103,7 @@ void forward_list_copy_to_array(void *const arr, forward_list me)
     while (traverse) {
         memcpy((char *) arr + offset, traverse + node_data_ptr_offset,
                me->bytes_per_item);
-        memcpy(&traverse, traverse + node_next_ptr_offset, sizeof(char *));
+        memcpy(&traverse, traverse + node_next_ptr_offset, ptr_size);
         offset += me->bytes_per_item;
     }
 }
@@ -119,9 +120,9 @@ static char *forward_list_get_node_at(forward_list me, const size_t index)
         return me->tail;
     }
     for (i = 0; i < index; i++) {
-        memcpy(&traverse, traverse + node_next_ptr_offset, sizeof(char *));
+        memcpy(&traverse, traverse + node_next_ptr_offset, ptr_size);
     }
-    memcpy(&traverse_next, traverse + node_next_ptr_offset, sizeof(char *));
+    memcpy(&traverse_next, traverse + node_next_ptr_offset, ptr_size);
     if (!traverse_next) {
         me->tail = traverse;
     }
@@ -167,21 +168,21 @@ int forward_list_add_at(forward_list me, const size_t index, void *const data)
     if (index > me->item_count) {
         return -EINVAL;
     }
-    node = malloc(sizeof(char *) + me->bytes_per_item);
+    node = malloc(ptr_size + me->bytes_per_item);
     if (!node) {
         return -ENOMEM;
     }
     memcpy(node + node_data_ptr_offset, data, me->bytes_per_item);
     if (index == 0) {
-        memcpy(node + node_next_ptr_offset, &me->head, sizeof(char *));
+        memcpy(node + node_next_ptr_offset, &me->head, ptr_size);
         me->head = node;
     } else {
         char *node_next;
         char *traverse = forward_list_get_node_at(me, index - 1);
         memcpy(node + node_next_ptr_offset, traverse + node_next_ptr_offset,
-               sizeof(char *));
-        memcpy(traverse + node_next_ptr_offset, &node, sizeof(char *));
-        memcpy(&node_next, node + node_next_ptr_offset, sizeof(char *));
+               ptr_size);
+        memcpy(traverse + node_next_ptr_offset, &node, ptr_size);
+        memcpy(&node_next, node + node_next_ptr_offset, ptr_size);
         if (!node_next) {
             me->tail = node;
         }
@@ -237,7 +238,7 @@ int forward_list_remove_at(forward_list me, const size_t index)
     }
     if (index == 0) {
         char *temp = me->head;
-        memcpy(&me->head, temp + node_next_ptr_offset, sizeof(char *));
+        memcpy(&me->head, temp + node_next_ptr_offset, ptr_size);
         if (!me->head) {
             me->tail = NULL;
         }
@@ -246,10 +247,10 @@ int forward_list_remove_at(forward_list me, const size_t index)
         char *traverse = forward_list_get_node_at(me, index - 1);
         char *backup;
         char *backup_next;
-        memcpy(&backup, traverse + node_next_ptr_offset, sizeof(char *));
+        memcpy(&backup, traverse + node_next_ptr_offset, ptr_size);
         memcpy(traverse + node_next_ptr_offset, backup + node_next_ptr_offset,
-               sizeof(char *));
-        memcpy(&backup_next, backup + node_next_ptr_offset, sizeof(char *));
+               ptr_size);
+        memcpy(&backup_next, backup + node_next_ptr_offset, ptr_size);
         if (!backup_next) {
             me->tail = NULL;
         }
@@ -407,7 +408,7 @@ void forward_list_clear(forward_list me)
     char *traverse = me->head;
     while (traverse) {
         char *temp = traverse;
-        memcpy(&traverse, traverse + node_next_ptr_offset, sizeof(char *));
+        memcpy(&traverse, traverse + node_next_ptr_offset, ptr_size);
         free(temp);
     }
     me->head = NULL;

--- a/src/include/forward_list.h
+++ b/src/include/forward_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,28 +34,28 @@ typedef struct internal_forward_list *forward_list;
 forward_list forward_list_init(size_t data_size);
 
 /* Utility */
-int forward_list_size(forward_list me);
+size_t forward_list_size(forward_list me);
 int forward_list_is_empty(forward_list me);
 void forward_list_copy_to_array(void *arr, forward_list me);
 
 /* Adding */
 int forward_list_add_first(forward_list me, void *data);
-int forward_list_add_at(forward_list me, int index, void *data);
+int forward_list_add_at(forward_list me, size_t index, void *data);
 int forward_list_add_last(forward_list me, void *data);
 
 /* Removing */
 int forward_list_remove_first(forward_list me);
-int forward_list_remove_at(forward_list me, int index);
+int forward_list_remove_at(forward_list me, size_t index);
 int forward_list_remove_last(forward_list me);
 
 /* Setting */
 int forward_list_set_first(forward_list me, void *data);
-int forward_list_set_at(forward_list me, int index, void *data);
+int forward_list_set_at(forward_list me, size_t index, void *data);
 int forward_list_set_last(forward_list me, void *data);
 
 /* Getting */
 int forward_list_get_first(void *data, forward_list me);
-int forward_list_get_at(void *data, forward_list me, int index);
+int forward_list_get_at(void *data, forward_list me, size_t index);
 int forward_list_get_last(void *data, forward_list me);
 
 /* Ending */


### PR DESCRIPTION
Ran test_puzzle_forwards(2, 5) for both new and old versions. Average speed of old version was 41.5 seconds and new version 26 seconds. 40% speed increase.