### PR TITLE
Reduce calls to malloc in unordered_multiset

### DIFF
--- a/src/include/unordered_multiset.h
+++ b/src/include/unordered_multiset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,12 +40,12 @@ unordered_multiset_init(size_t key_size,
 
 /* Utility */
 int unordered_multiset_rehash(unordered_multiset me);
-int unordered_multiset_size(unordered_multiset me);
+size_t unordered_multiset_size(unordered_multiset me);
 int unordered_multiset_is_empty(unordered_multiset me);
 
 /* Accessing */
 int unordered_multiset_put(unordered_multiset me, void *key);
-int unordered_multiset_count(unordered_multiset me, void *key);
+size_t unordered_multiset_count(unordered_multiset me, void *key);
 int unordered_multiset_contains(unordered_multiset me, void *key);
 int unordered_multiset_remove(unordered_multiset me, void *key);
 int unordered_multiset_remove_all(unordered_multiset me, void *key);

--- a/src/unordered_multiset.c
+++ b/src/unordered_multiset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,26 +24,28 @@
 #include <errno.h>
 #include "include/unordered_multiset.h"
 
-static const int STARTING_BUCKETS = 8;
-static const double RESIZE_AT = 0.75;
-static const double RESIZE_RATIO = 1.5;
+#define STARTING_BUCKETS 16
+#define RESIZE_AT 0.75
+#define RESIZE_RATIO 2
 
 struct internal_unordered_multiset {
     size_t key_size;
+    size_t size;
+    size_t capacity;
+    size_t used;
     unsigned long (*hash)(const void *const key);
     int (*comparator)(const void *const one, const void *const two);
-    int size;
-    int used;
-    int capacity;
-    struct node **buckets;
+    char **buckets;
 };
 
-struct node {
-    int count;
-    void *key;
-    unsigned long hash;
-    struct node *next;
-};
+static const size_t ptr_size = sizeof(char *);
+static const size_t count_size = sizeof(size_t);
+static const size_t hash_size = sizeof(unsigned long);
+static const size_t node_next_offset = 0;
+static const size_t node_count_offset = sizeof(char *);
+static const size_t node_hash_offset = sizeof(char *) + sizeof(size_t);
+static const size_t node_key_offset =
+        sizeof(char *) + sizeof(size_t) + sizeof(unsigned long);
 
 /*
  * Gets the hash by first calling the user-defined hash, and then using a
@@ -89,9 +91,9 @@ unordered_multiset_init(const size_t key_size,
     init->hash = hash;
     init->comparator = comparator;
     init->size = 0;
-    init->used = 0;
     init->capacity = STARTING_BUCKETS;
-    init->buckets = calloc(STARTING_BUCKETS, sizeof(struct node *));
+    init->used = 0;
+    init->buckets = calloc(STARTING_BUCKETS, ptr_size);
     if (!init->buckets) {
         free(init);
         return NULL;
@@ -102,21 +104,26 @@ unordered_multiset_init(const size_t key_size,
 /*
  * Adds the specified node to the multi-set.
  */
-static void unordered_multiset_add_item(unordered_multiset me,
-                                        struct node *const add)
+static void unordered_multiset_add_item(unordered_multiset me, char *const add)
 {
-    struct node *traverse;
-    const int index = (int) (add->hash % me->capacity);
-    add->next = NULL;
+    char *traverse;
+    char *traverse_next;
+    unsigned long hash;
+    size_t index;
+    memcpy(&hash, add + node_hash_offset, hash_size);
+    index = hash % me->capacity;
+    memset(add + node_next_offset, 0, ptr_size);
     if (!me->buckets[index]) {
         me->buckets[index] = add;
         return;
     }
     traverse = me->buckets[index];
-    while (traverse->next) {
-        traverse = traverse->next;
+    memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
+    while (traverse_next) {
+        traverse = traverse_next;
+        memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
     }
-    traverse->next = add;
+    memcpy(traverse + node_next_offset, &add, ptr_size);
 }
 
 /**
@@ -130,18 +137,21 @@ static void unordered_multiset_add_item(unordered_multiset me,
  */
 int unordered_multiset_rehash(unordered_multiset me)
 {
-    int i;
-    struct node **old_buckets = me->buckets;
-    me->buckets = calloc((size_t) me->capacity, sizeof(struct node *));
+    size_t i;
+    char **old_buckets = me->buckets;
+    me->buckets = calloc(me->capacity, ptr_size);
     if (!me->buckets) {
         me->buckets = old_buckets;
         return -ENOMEM;
     }
     for (i = 0; i < me->capacity; i++) {
-        struct node *traverse = old_buckets[i];
+        char *traverse = old_buckets[i];
         while (traverse) {
-            struct node *const backup = traverse->next;
-            traverse->hash = unordered_multiset_hash(me, traverse->key);
+            char *backup;
+            unsigned long hash;
+            memcpy(&backup, traverse + node_next_offset, ptr_size);
+            hash = unordered_multiset_hash(me, traverse + node_key_offset);
+            memcpy(traverse + node_hash_offset, &hash, hash_size);
             unordered_multiset_add_item(me, traverse);
             traverse = backup;
         }
@@ -157,7 +167,7 @@ int unordered_multiset_rehash(unordered_multiset me)
  *
  * @return the size of the unordered multi-set
  */
-int unordered_multiset_size(unordered_multiset me)
+size_t unordered_multiset_size(unordered_multiset me)
 {
     return me->size;
 }
@@ -179,20 +189,21 @@ int unordered_multiset_is_empty(unordered_multiset me)
  */
 static int unordered_multiset_resize(unordered_multiset me)
 {
-    int i;
-    const int old_capacity = me->capacity;
-    const int new_capacity = (int) (me->capacity * RESIZE_RATIO);
-    struct node **old_buckets = me->buckets;
-    me->buckets = calloc((size_t) new_capacity, sizeof(struct node *));
+    size_t i;
+    const size_t old_capacity = me->capacity;
+    const size_t new_capacity = me->capacity * RESIZE_RATIO;
+    char **old_buckets = me->buckets;
+    me->buckets = calloc(new_capacity, ptr_size);
     if (!me->buckets) {
         me->buckets = old_buckets;
         return -ENOMEM;
     }
     me->capacity = new_capacity;
     for (i = 0; i < old_capacity; i++) {
-        struct node *traverse = old_buckets[i];
+        char *traverse = old_buckets[i];
         while (traverse) {
-            struct node *const backup = traverse->next;
+            char *backup;
+            memcpy(&backup, traverse + node_next_offset, ptr_size);
             unordered_multiset_add_item(me, traverse);
             traverse = backup;
         }
@@ -204,34 +215,32 @@ static int unordered_multiset_resize(unordered_multiset me)
 /*
  * Determines if an element is equal to the key.
  */
-static int unordered_multiset_is_equal(unordered_multiset me,
-                                       const struct node *const item,
+static int unordered_multiset_is_equal(unordered_multiset me, char *const item,
                                        const unsigned long hash,
                                        const void *const key)
 {
-    return item->hash == hash && me->comparator(item->key, key) == 0;
+    unsigned long item_hash;
+    memcpy(&item_hash, item + node_hash_offset, hash_size);
+    return item_hash == hash &&
+           me->comparator(item + node_key_offset, key) == 0;
 }
 
 /*
  * Creates an element to add.
  */
-static struct node *unordered_multiset_create_element(unordered_multiset me,
-                                                      const unsigned long hash,
-                                                      const void *const key)
+static char *unordered_multiset_create_element(unordered_multiset me,
+                                               const unsigned long hash,
+                                               const void *const key)
 {
-    struct node *const init = malloc(sizeof(struct node));
+    const size_t one = 1;
+    char *init = malloc(ptr_size + count_size + hash_size + me->key_size);
     if (!init) {
         return NULL;
     }
-    init->count = 1;
-    init->key = malloc(me->key_size);
-    if (!init->key) {
-        free(init);
-        return NULL;
-    }
-    memcpy(init->key, key, me->key_size);
-    init->hash = hash;
-    init->next = NULL;
+    memset(init + node_next_offset, 0, ptr_size);
+    memcpy(init + node_count_offset, &one, count_size);
+    memcpy(init + node_hash_offset, &hash, hash_size);
+    memcpy(init + node_key_offset, key, me->key_size);
     return init;
 }
 
@@ -252,37 +261,47 @@ int unordered_multiset_put(unordered_multiset me, void *const key)
 {
     const unsigned long hash = unordered_multiset_hash(me, key);
     int index;
-    if (me->used + 1 >= RESIZE_AT * me->capacity) {
+    if (me->used + 1 >= (size_t) (RESIZE_AT * me->capacity)) {
         const int rc = unordered_multiset_resize(me);
         if (rc != 0) {
             return rc;
         }
     }
-    index = (int) (hash % me->capacity);
+    index = (size_t) (hash % me->capacity);
     if (!me->buckets[index]) {
         me->buckets[index] = unordered_multiset_create_element(me, hash, key);
         if (!me->buckets[index]) {
             return -ENOMEM;
         }
     } else {
-        struct node *traverse = me->buckets[index];
+        char *traverse = me->buckets[index];
+        char *traverse_next;
         if (unordered_multiset_is_equal(me, traverse, hash, key)) {
-            traverse->count++;
+            size_t count;
+            memcpy(&count, traverse + node_count_offset, count_size);
+            count++;
+            memcpy(traverse + node_count_offset, &count, count_size);
             me->size++;
             return 0;
         }
-        while (traverse->next) {
-            traverse = traverse->next;
+        memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
+        while (traverse_next) {
+            traverse = traverse_next;
+            memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
             if (unordered_multiset_is_equal(me, traverse, hash, key)) {
-                traverse->count++;
+                size_t count;
+                memcpy(&count, traverse + node_count_offset, count_size);
+                count++;
+                memcpy(traverse + node_count_offset, &count, count_size);
                 me->size++;
                 return 0;
             }
         }
-        traverse->next = unordered_multiset_create_element(me, hash, key);
-        if (!traverse->next) {
+        traverse_next = unordered_multiset_create_element(me, hash, key);
+        if (!traverse_next) {
             return -ENOMEM;
         }
+        memcpy(traverse + node_next_offset, &traverse_next, ptr_size);
     }
     me->size++;
     me->used++;
@@ -301,16 +320,17 @@ int unordered_multiset_put(unordered_multiset me, void *const key)
  *
  * @return the count of a specific key in the unordered multi-set
  */
-int unordered_multiset_count(unordered_multiset me, void *const key)
+size_t unordered_multiset_count(unordered_multiset me, void *const key)
 {
     const unsigned long hash = unordered_multiset_hash(me, key);
-    const int index = (int) (hash % me->capacity);
-    const struct node *traverse = me->buckets[index];
+    char *traverse = me->buckets[hash % me->capacity];
     while (traverse) {
         if (unordered_multiset_is_equal(me, traverse, hash, key)) {
-            return traverse->count;
+            size_t count;
+            memcpy(&count, traverse + node_count_offset, count_size);
+            return count;
         }
-        traverse = traverse->next;
+        memcpy(&traverse, traverse + node_next_offset, ptr_size);
     }
     return 0;
 }
@@ -329,7 +349,7 @@ int unordered_multiset_count(unordered_multiset me, void *const key)
  */
 int unordered_multiset_contains(unordered_multiset me, void *const key)
 {
-    return unordered_multiset_count(me, key) > 0;
+    return unordered_multiset_count(me, key) != 0;
 }
 
 /**
@@ -346,38 +366,47 @@ int unordered_multiset_contains(unordered_multiset me, void *const key)
  */
 int unordered_multiset_remove(unordered_multiset me, void *const key)
 {
-    struct node *traverse;
+    char *traverse;
+    char *traverse_next;
     const unsigned long hash = unordered_multiset_hash(me, key);
-    const int index = (int) (hash % me->capacity);
+    const size_t index = hash % me->capacity;
     if (!me->buckets[index]) {
         return 0;
     }
     traverse = me->buckets[index];
     if (unordered_multiset_is_equal(me, traverse, hash, key)) {
-        traverse->count--;
-        if (traverse->count == 0) {
-            me->buckets[index] = traverse->next;
-            free(traverse->key);
+        size_t count;
+        memcpy(&count, traverse + node_count_offset, count_size);
+        if (count == 1) {
+            memcpy(me->buckets + index, traverse + node_next_offset, ptr_size);
             free(traverse);
             me->used--;
+        } else {
+            count--;
+            memcpy(traverse + node_count_offset, &count, count_size);
         }
         me->size--;
         return 1;
     }
-    while (traverse->next) {
-        if (unordered_multiset_is_equal(me, traverse->next, hash, key)) {
-            struct node *const backup = traverse->next;
-            backup->count--;
-            if (backup->count == 0) {
-                traverse->next = traverse->next->next;
-                free(backup->key);
-                free(backup);
+    memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
+    while (traverse_next) {
+        if (unordered_multiset_is_equal(me, traverse_next, hash, key)) {
+            size_t count;
+            memcpy(&count, traverse_next + node_count_offset, count_size);
+            if (count == 1) {
+                memcpy(traverse + node_next_offset,
+                       traverse_next + node_next_offset, ptr_size);
+                free(traverse_next);
                 me->used--;
+            } else {
+                count--;
+                memcpy(traverse_next + node_count_offset, &count, count_size);
             }
             me->size--;
             return 1;
         }
-        traverse = traverse->next;
+        traverse = traverse_next;
+        memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
     }
     return 0;
 }
@@ -396,32 +425,37 @@ int unordered_multiset_remove(unordered_multiset me, void *const key)
  */
 int unordered_multiset_remove_all(unordered_multiset me, void *const key)
 {
-    struct node *traverse;
+    char *traverse;
+    char *traverse_next;
     const unsigned long hash = unordered_multiset_hash(me, key);
-    const int index = (int) (hash % me->capacity);
+    const size_t index = hash % me->capacity;
     if (!me->buckets[index]) {
         return 0;
     }
     traverse = me->buckets[index];
     if (unordered_multiset_is_equal(me, traverse, hash, key)) {
-        me->buckets[index] = traverse->next;
-        me->size -= traverse->count;
-        free(traverse->key);
+        size_t count;
+        memcpy(&count, traverse + node_count_offset, count_size);
+        memcpy(me->buckets + index, traverse + node_next_offset, ptr_size);
         free(traverse);
         me->used--;
+        me->size -= count;
         return 1;
     }
-    while (traverse->next) {
-        if (unordered_multiset_is_equal(me, traverse->next, hash, key)) {
-            struct node *const backup = traverse->next;
-            traverse->next = traverse->next->next;
-            me->size -= backup->count;
-            free(backup->key);
-            free(backup);
+    memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
+    while (traverse_next) {
+        if (unordered_multiset_is_equal(me, traverse_next, hash, key)) {
+            size_t count;
+            memcpy(&count, traverse_next + node_count_offset, count_size);
+            memcpy(traverse + node_next_offset,
+                   traverse_next + node_next_offset, ptr_size);
+            free(traverse_next);
             me->used--;
+            me->size -= count;
             return 1;
         }
-        traverse = traverse->next;
+        traverse = traverse_next;
+        memcpy(&traverse_next, traverse + node_next_offset, ptr_size);
     }
     return 0;
 }
@@ -436,27 +470,23 @@ int unordered_multiset_remove_all(unordered_multiset me, void *const key)
  */
 int unordered_multiset_clear(unordered_multiset me)
 {
-    int i;
-    struct node **temp =
-            calloc((size_t) STARTING_BUCKETS, sizeof(struct node *));
-    if (!temp) {
+    size_t i;
+    char **updated_buckets = calloc(STARTING_BUCKETS, ptr_size);
+    if (!updated_buckets) {
         return -ENOMEM;
     }
     for (i = 0; i < me->capacity; i++) {
-        struct node *traverse = me->buckets[i];
+        char *traverse = me->buckets[i];
         while (traverse) {
-            struct node *const backup = traverse;
-            traverse = traverse->next;
-            free(backup->key);
+            char *backup = traverse;
+            memcpy(&traverse, traverse + node_next_offset, ptr_size);
             free(backup);
         }
-        me->buckets[i] = NULL;
     }
     me->size = 0;
-    me->used = 0;
     me->capacity = STARTING_BUCKETS;
-    free(me->buckets);
-    me->buckets = temp;
+    me->used = 0;
+    me->buckets = updated_buckets;
     return 0;
 }
 

--- a/tst/test_unordered_multiset.c
+++ b/tst/test_unordered_multiset.c
@@ -128,12 +128,12 @@ static void test_remove(unordered_multiset me)
 static void test_stress_remove(unordered_multiset me)
 {
     int i;
-    for (i = 5000; i < 6000; i++) {
+    for (i = 4000; i < 6000; i++) {
         unordered_multiset_put(me, &i);
         assert(unordered_multiset_contains(me, &i));
     }
-    assert(unordered_multiset_size(me) == 1000);
-    for (i = 5000; i < 6000; i++) {
+    assert(unordered_multiset_size(me) == 2000);
+    for (i = 4000; i < 6000; i++) {
         unordered_multiset_remove(me, &i);
         assert(!unordered_multiset_contains(me, &i));
     }

--- a/tst/test_unordered_multiset.c
+++ b/tst/test_unordered_multiset.c
@@ -279,14 +279,12 @@ static void test_put_out_of_memory(void)
     fail_malloc = 1;
     assert(unordered_multiset_put(me, &key) == -ENOMEM);
     fail_malloc = 1;
-    delay_fail_malloc = 1;
     assert(unordered_multiset_put(me, &key) == -ENOMEM);
     assert(unordered_multiset_put(me, &key) == 0);
     key = 7;
     fail_malloc = 1;
     assert(unordered_multiset_put(me, &key) == -ENOMEM);
     fail_malloc = 1;
-    delay_fail_malloc = 1;
     assert(unordered_multiset_put(me, &key) == -ENOMEM);
     assert(!unordered_multiset_destroy(me));
 }
@@ -298,15 +296,15 @@ static void test_resize_out_of_memory(void)
     int i;
     unordered_multiset me = unordered_multiset_init(sizeof(int), hash_int,
                                                     compare_int);
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < 11; i++) {
         assert(unordered_multiset_put(me, &i) == 0);
     }
-    assert(unordered_multiset_size(me) == 5);
+    assert(unordered_multiset_size(me) == 11);
     i++;
     fail_calloc = 1;
     assert(unordered_multiset_put(me, &i) == -ENOMEM);
-    assert(unordered_multiset_size(me) == 5);
-    for (i = 0; i < 5; i++) {
+    assert(unordered_multiset_size(me) == 11);
+    for (i = 0; i < 11; i++) {
         assert(unordered_multiset_contains(me, &i));
     }
     assert(!unordered_multiset_destroy(me));


### PR DESCRIPTION
Using this as a test:
```
    unordered_multiset me = unordered_multiset_init(sizeof(int), hash_int, compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        unordered_multiset_put(me, &i);
    }
    for (i = 0; i < 1000000; i++) {
        count += unordered_multiset_contains(me, &i);
    }
    printf("%d\n", count);
    unordered_multiset_destroy(me);
```
The new version ran in 0.31s and the old version in 0.51s, which improves efficiency by 40%.