### PR TITLE
Reduce calls to malloc in unordered_map

### DIFF
--- a/containers.h
+++ b/containers.h
@@ -47,7 +47,7 @@ unordered_map unordered_map_init(size_t key_size,
 
 /* Utility */
 int unordered_map_rehash(unordered_map me);
-int unordered_map_size(unordered_map me);
+size_t unordered_map_size(unordered_map me);
 int unordered_map_is_empty(unordered_map me);
 
 /* Accessing */
@@ -116,12 +116,12 @@ unordered_multiset_init(size_t key_size,
 
 /* Utility */
 int unordered_multiset_rehash(unordered_multiset me);
-int unordered_multiset_size(unordered_multiset me);
+size_t unordered_multiset_size(unordered_multiset me);
 int unordered_multiset_is_empty(unordered_multiset me);
 
 /* Accessing */
 int unordered_multiset_put(unordered_multiset me, void *key);
-int unordered_multiset_count(unordered_multiset me, void *key);
+size_t unordered_multiset_count(unordered_multiset me, void *key);
 int unordered_multiset_contains(unordered_multiset me, void *key);
 int unordered_multiset_remove(unordered_multiset me, void *key);
 int unordered_multiset_remove_all(unordered_multiset me, void *key);

--- a/src/include/unordered_map.h
+++ b/src/include/unordered_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ unordered_map unordered_map_init(size_t key_size,
 
 /* Utility */
 int unordered_map_rehash(unordered_map me);
-int unordered_map_size(unordered_map me);
+size_t unordered_map_size(unordered_map me);
 int unordered_map_is_empty(unordered_map me);
 
 /* Accessing */

--- a/tst/test_unordered_map.c
+++ b/tst/test_unordered_map.c
@@ -243,21 +243,9 @@ static void test_put_out_of_memory(void)
     assert(me);
     fail_malloc = 1;
     assert(unordered_map_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(unordered_map_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
-    assert(unordered_map_put(me, &key, &value) == -ENOMEM);
     assert(unordered_map_put(me, &key, &value) == 0);
     key = 7;
     fail_malloc = 1;
-    assert(unordered_map_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(unordered_map_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
     assert(unordered_map_put(me, &key, &value) == -ENOMEM);
     assert(!unordered_map_destroy(me));
 }
@@ -269,15 +257,15 @@ static void test_resize_out_of_memory(void)
     int i;
     unordered_map me = unordered_map_init(sizeof(int), sizeof(int), hash_int,
                                           compare_int);
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < 11; i++) {
         assert(unordered_map_put(me, &i, &i) == 0);
     }
-    assert(unordered_map_size(me) == 5);
+    assert(unordered_map_size(me) == 11);
     i++;
     fail_calloc = 1;
     assert(unordered_map_put(me, &i, &i) == -ENOMEM);
-    assert(unordered_map_size(me) == 5);
-    for (i = 0; i < 5; i++) {
+    assert(unordered_map_size(me) == 11);
+    for (i = 0; i < 11; i++) {
         assert(unordered_map_contains(me, &i));
     }
     assert(!unordered_map_destroy(me));


### PR DESCRIPTION
For test, used this function:
```
    unordered_map me = unordered_map_init(sizeof(int), sizeof(double), hash_int,
                                                                            compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        double number = i + 0.5;
        unordered_map_put(me, &i, &number);
    }
    for (i = 0; i < 1000000; i++) {
        double get;
        unordered_map_get(&get, me, &i);
        assert(get < i + 0.6);
        assert(get > i + 0.4);
        count += unordered_map_contains(me, &i);
    }
    printf("%d\n", count);
    unordered_map_destroy(me);
```
The old version would take 0.7s, the new one 0.32s. This is twice as fast.