### PR TITLE
Reduce calls to malloc in unordered_multimap

### DIFF
--- a/containers.h
+++ b/containers.h
@@ -276,7 +276,7 @@ unordered_multimap_init(size_t key_size,
 
 /* Utility */
 int unordered_multimap_rehash(unordered_multimap me);
-int unordered_multimap_size(unordered_multimap me);
+size_t unordered_multimap_size(unordered_multimap me);
 int unordered_multimap_is_empty(unordered_multimap me);
 
 /* Accessing */

--- a/src/include/unordered_multimap.h
+++ b/src/include/unordered_multimap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,7 +43,7 @@ unordered_multimap_init(size_t key_size,
 
 /* Utility */
 int unordered_multimap_rehash(unordered_multimap me);
-int unordered_multimap_size(unordered_multimap me);
+size_t unordered_multimap_size(unordered_multimap me);
 int unordered_multimap_is_empty(unordered_multimap me);
 
 /* Accessing */

--- a/tst/test_unordered_multimap.c
+++ b/tst/test_unordered_multimap.c
@@ -292,6 +292,7 @@ static void test_bad_hash_collision(void)
     value = 13;
     unordered_multimap_put(me, &key, &value);
     unordered_multimap_get_start(me, &key);
+    key = 0xfacade;
     value = 20;
     unordered_multimap_get_next(&value, me);
     assert(value == 12);
@@ -350,21 +351,9 @@ static void test_put_out_of_memory(void)
     assert(me);
     fail_malloc = 1;
     assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
-    assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
     assert(unordered_multimap_put(me, &key, &value) == 0);
     key = 7;
     fail_malloc = 1;
-    assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
     assert(unordered_multimap_put(me, &key, &value) == -ENOMEM);
     assert(!unordered_multimap_destroy(me));
 }
@@ -377,15 +366,15 @@ static void test_resize_out_of_memory(void)
     unordered_multimap me = unordered_multimap_init(sizeof(int), sizeof(int),
                                                     hash_int, compare_int,
                                                     compare_int);
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < 11; i++) {
         assert(unordered_multimap_put(me, &i, &i) == 0);
     }
-    assert(unordered_multimap_size(me) == 5);
+    assert(unordered_multimap_size(me) == 11);
     i++;
     fail_calloc = 1;
     assert(unordered_multimap_put(me, &i, &i) == -ENOMEM);
-    assert(unordered_multimap_size(me) == 5);
-    for (i = 0; i < 5; i++) {
+    assert(unordered_multimap_size(me) == 11);
+    for (i = 0; i < 11; i++) {
         assert(unordered_multimap_contains(me, &i));
     }
     assert(!unordered_multimap_destroy(me));


### PR DESCRIPTION
Using the following code:
```
    unordered_multimap me = unordered_multimap_init(sizeof(int), sizeof(double),
                                                    hash_int, compare_int,
                                                    compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        int j;
        for (j = 0; j < 5; j++) {
            unordered_multimap_put(me, &i, &j);
        }
    }
    for (i = 0; i < 1000000; i++) {
        int j = 0;
        int get;
        unordered_multimap_get_start(me, &i);
        while (unordered_multimap_get_next(&get, me)) {
            if (get == j) {
                count++;
            }
            j++;
        }
    }
    printf("%d\n", count);
    unordered_multimap_destroy(me);
```
The old version would run in 3.63s and the new version in 1.52s which a 60% improvement.