### PR TITLE
Reduce calls to malloc in set

### DIFF
--- a/containers.h
+++ b/containers.h
@@ -617,7 +617,7 @@ set set_init(size_t key_size,
              int (*comparator)(const void *const one, const void *const two));
 
 /* Capacity */
-int set_size(set me);
+size_t set_size(set me);
 int set_is_empty(set me);
 
 /* Accessing */

--- a/src/include/set.h
+++ b/src/include/set.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ set set_init(size_t key_size,
              int (*comparator)(const void *const one, const void *const two));
 
 /* Capacity */
-int set_size(set me);
+size_t set_size(set me);
 int set_is_empty(set me);
 
 /* Accessing */

--- a/src/set.c
+++ b/src/set.c
@@ -98,13 +98,15 @@ static void set_reference_parent(set me, char *const parent, char *const child)
 {
     char *grand_parent;
     char *grand_parent_left_child;
-    memcpy(&grand_parent, parent + node_parent_offset, ptr_size);
     memcpy(child + node_parent_offset, parent + node_parent_offset, ptr_size);
-    memcpy(&grand_parent_left_child, grand_parent + node_left_child_offset,
-           ptr_size);
+    memcpy(&grand_parent, parent + node_parent_offset, ptr_size);
     if (!grand_parent) {
         me->root = child;
-    } else if (grand_parent_left_child == parent) {
+        return;
+    }
+    memcpy(&grand_parent_left_child, grand_parent + node_left_child_offset,
+           ptr_size);
+    if (grand_parent_left_child == parent) {
         memcpy(grand_parent + node_left_child_offset, &child, ptr_size);
     } else {
         memcpy(grand_parent + node_right_child_offset, &child, ptr_size);
@@ -573,7 +575,6 @@ static void set_remove_two_children(set me, const char *const traverse)
     char *item_parent;
     char *parent;
     char *traverse_parent;
-    char *traverse_parent_left;
     char *traverse_right;
     char *traverse_right_left;
     int is_left_deleted;
@@ -583,7 +584,7 @@ static void set_remove_two_children(set me, const char *const traverse)
     is_left_deleted = traverse_right_left != NULL;
     if (!is_left_deleted) {
         char *item_left;
-        item = traverse_right;
+        memcpy(&item, traverse + node_right_child_offset, ptr_size);
         parent = item;
         item[0] = traverse[0];
         memcpy(item + node_parent_offset, traverse + node_parent_offset,
@@ -613,6 +614,7 @@ static void set_remove_two_children(set me, const char *const traverse)
         }
         memcpy(item + node_left_child_offset, traverse + node_left_child_offset,
                ptr_size);
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
         memcpy(item_left + node_parent_offset, &item, ptr_size);
         memcpy(item + node_right_child_offset,
                traverse + node_right_child_offset, ptr_size);
@@ -621,16 +623,19 @@ static void set_remove_two_children(set me, const char *const traverse)
         memcpy(item + node_parent_offset, traverse + node_parent_offset,
                ptr_size);
     }
-    memcpy(&item_parent, item + node_parent_offset, ptr_size);
     memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
-    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
-           ptr_size);
     if (!traverse_parent) {
         me->root = item;
-    } else if (traverse_parent_left == traverse) {
-        memcpy(item_parent + node_left_child_offset, &item, ptr_size);
     } else {
-        memcpy(item_parent + node_right_child_offset, &item, ptr_size);
+        char *traverse_parent_left;
+        memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+               ptr_size);
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        if (traverse_parent_left == traverse) {
+            memcpy(item_parent + node_left_child_offset, &item, ptr_size);
+        } else {
+            memcpy(item_parent + node_right_child_offset, &item, ptr_size);
+        }
     }
     set_delete_balance(me, parent, is_left_deleted);
 }

--- a/src/set.c
+++ b/src/set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,9 +25,9 @@
 #include "include/set.h"
 
 struct internal_set {
+    size_t size;
     size_t key_size;
     int (*comparator)(const void *const one, const void *const two);
-    int size;
     struct node *root;
 };
 
@@ -75,7 +75,7 @@ set set_init(const size_t key_size,
  *
  * @return the size of the set
  */
-int set_size(set me)
+size_t set_size(set me)
 {
     return me->size;
 }

--- a/src/set.c
+++ b/src/set.c
@@ -28,16 +28,15 @@ struct internal_set {
     size_t size;
     size_t key_size;
     int (*comparator)(const void *const one, const void *const two);
-    struct node *root;
+    char *root;
 };
 
-struct node {
-    struct node *parent;
-    int balance;
-    void *key;
-    struct node *left;
-    struct node *right;
-};
+static const size_t ptr_size = sizeof(char *);
+/* Node balance is always the first byte (at index 0). */
+static const size_t node_parent_offset = sizeof(signed char);
+static const size_t node_left_child_offset = 1 + sizeof(char *);
+static const size_t node_right_child_offset = 1 + 2 * sizeof(char *);
+static const size_t node_key_offset = 1 + 3 * sizeof(char *);
 
 /**
  * Initializes a set.
@@ -61,9 +60,9 @@ set set_init(const size_t key_size,
     if (!init) {
         return NULL;
     }
+    init->size = 0;
     init->key_size = key_size;
     init->comparator = comparator;
-    init->size = 0;
     init->root = NULL;
     return init;
 }
@@ -95,70 +94,67 @@ int set_is_empty(set me)
 /*
  * Resets the parent reference.
  */
-static void set_reference_parent(set me,
-                                 struct node *const parent,
-                                 struct node *const child)
+static void set_reference_parent(set me, char *const parent, char *const child)
 {
-    child->parent = parent->parent;
-    if (!parent->parent) {
+    char *grand_parent;
+    char *grand_parent_left_child;
+    memcpy(&grand_parent, parent + node_parent_offset, ptr_size);
+    memcpy(child + node_parent_offset, parent + node_parent_offset, ptr_size);
+    memcpy(&grand_parent_left_child, grand_parent + node_left_child_offset,
+           ptr_size);
+    if (!grand_parent) {
         me->root = child;
-    } else if (parent->parent->left == parent) {
-        parent->parent->left = child;
+    } else if (grand_parent_left_child == parent) {
+        memcpy(grand_parent + node_left_child_offset, &child, ptr_size);
     } else {
-        parent->parent->right = child;
+        memcpy(grand_parent + node_right_child_offset, &child, ptr_size);
     }
 }
 
 /*
  * Rotates the AVL tree to the left.
  */
-static void set_rotate_left(set me,
-                            struct node *const parent,
-                            struct node *const child)
+static void set_rotate_left(set me, char *const parent, char *const child)
 {
-    struct node *grand_child;
+    char *left_grand_child;
     set_reference_parent(me, parent, child);
-    grand_child = child->left;
-    if (grand_child) {
-        grand_child->parent = parent;
+    memcpy(&left_grand_child, child + node_left_child_offset, ptr_size);
+    if (left_grand_child) {
+        memcpy(left_grand_child + node_parent_offset, &parent, ptr_size);
     }
-    parent->parent = child;
-    parent->right = grand_child;
-    child->left = parent;
+    memcpy(parent + node_parent_offset, &child, ptr_size);
+    memcpy(parent + node_right_child_offset, &left_grand_child, ptr_size);
+    memcpy(child + node_left_child_offset, &parent, ptr_size);
 }
 
 /*
  * Rotates the AVL tree to the right.
  */
-static void set_rotate_right(set me,
-                             struct node *const parent,
-                             struct node *const child)
+static void set_rotate_right(set me, char *const parent, char *const child)
 {
-    struct node *grand_child;
+    char *right_grand_child;
     set_reference_parent(me, parent, child);
-    grand_child = child->right;
-    if (grand_child) {
-        grand_child->parent = parent;
+    memcpy(&right_grand_child, child + node_right_child_offset, ptr_size);
+    if (right_grand_child) {
+        memcpy(right_grand_child + node_parent_offset, &parent, ptr_size);
     }
-    parent->parent = child;
-    parent->left = grand_child;
-    child->right = parent;
+    memcpy(parent + node_parent_offset, &child, ptr_size);
+    memcpy(parent + node_left_child_offset, &right_grand_child, ptr_size);
+    memcpy(child + node_right_child_offset, &parent, ptr_size);
 }
 
 /*
  * Performs a left repair.
  */
-static struct node *set_repair_left(set me,
-                                    struct node *const parent,
-                                    struct node *const child)
+static char *set_repair_left(set me, char *const parent, char *const child)
 {
     set_rotate_left(me, parent, child);
-    if (child->balance == 0) {
-        parent->balance = 1;
-        child->balance = -1;
+    if (child[0] == 0) {
+        parent[0] = 1;
+        child[0] = -1;
     } else {
-        parent->balance = 0;
-        child->balance = 0;
+        parent[0] = 0;
+        child[0] = 0;
     }
     return child;
 }
@@ -166,17 +162,15 @@ static struct node *set_repair_left(set me,
 /*
  * Performs a right repair.
  */
-static struct node *set_repair_right(set me,
-                                     struct node *const parent,
-                                     struct node *const child)
+static char *set_repair_right(set me, char *const parent, char *const child)
 {
     set_rotate_right(me, parent, child);
-    if (child->balance == 0) {
-        parent->balance = -1;
-        child->balance = 1;
+    if (child[0] == 0) {
+        parent[0] = -1;
+        child[0] = 1;
     } else {
-        parent->balance = 0;
-        child->balance = 0;
+        parent[0] = 0;
+        child[0] = 0;
     }
     return child;
 }
@@ -184,48 +178,44 @@ static struct node *set_repair_right(set me,
 /*
  * Performs a left-right repair.
  */
-static struct node *set_repair_left_right(set me,
-                                          struct node *const parent,
-                                          struct node *const child,
-                                          struct node *const grand_child)
+static char *set_repair_left_right(set me, char *const parent,
+                                   char *const child, char *const grand_child)
 {
     set_rotate_left(me, child, grand_child);
     set_rotate_right(me, parent, grand_child);
-    if (grand_child->balance == 1) {
-        parent->balance = 0;
-        child->balance = -1;
-    } else if (grand_child->balance == 0) {
-        parent->balance = 0;
-        child->balance = 0;
+    if (grand_child[0] == 1) {
+        parent[0] = 0;
+        child[0] = -1;
+    } else if (grand_child[0] == 0) {
+        parent[0] = 0;
+        child[0] = 0;
     } else {
-        parent->balance = 1;
-        child->balance = 0;
+        parent[0] = 1;
+        child[0] = 0;
     }
-    grand_child->balance = 0;
+    grand_child[0] = 0;
     return grand_child;
 }
 
 /*
  * Performs a right-left repair.
  */
-static struct node *set_repair_right_left(set me,
-                                          struct node *const parent,
-                                          struct node *const child,
-                                          struct node *const grand_child)
+static char *set_repair_right_left(set me, char *const parent,
+                                   char *const child, char *const grand_child)
 {
     set_rotate_right(me, child, grand_child);
     set_rotate_left(me, parent, grand_child);
-    if (grand_child->balance == 1) {
-        parent->balance = -1;
-        child->balance = 0;
-    } else if (grand_child->balance == 0) {
-        parent->balance = 0;
-        child->balance = 0;
+    if (grand_child[0] == 1) {
+        parent[0] = -1;
+        child[0] = 0;
+    } else if (grand_child[0] == 0) {
+        parent[0] = 0;
+        child[0] = 0;
     } else {
-        parent->balance = 0;
-        child->balance = 1;
+        parent[0] = 0;
+        child[0] = 1;
     }
-    grand_child->balance = 0;
+    grand_child[0] = 0;
     return grand_child;
 }
 
@@ -233,18 +223,16 @@ static struct node *set_repair_right_left(set me,
  * Repairs the AVL tree on insert. The only possible values of parent->balance
  * are {-2, 2} and the only possible values of child->balance are {-1, 0, 1}.
  */
-static struct node *set_repair(set me,
-                               struct node *const parent,
-                               struct node *const child,
-                               struct node *const grand_child)
+static char *set_repair(set me, char *const parent, char *const child,
+                        char *const grand_child)
 {
-    if (parent->balance == 2) {
-        if (child->balance == -1) {
+    if (parent[0] == 2) {
+        if (child[0] == -1) {
             return set_repair_right_left(me, parent, child, grand_child);
         }
         return set_repair_left(me, parent, child);
     }
-    if (child->balance == 1) {
+    if (child[0] == 1) {
         return set_repair_left_right(me, parent, child, grand_child);
     }
     return set_repair_right(me, parent, child);
@@ -253,54 +241,50 @@ static struct node *set_repair(set me,
 /*
  * Balances the AVL tree on insert.
  */
-static void set_insert_balance(set me, struct node *const item)
+static void set_insert_balance(set me, char *const item)
 {
-    struct node *grand_child = NULL;
-    struct node *child = item;
-    struct node *parent = item->parent;
+    char *grand_child = NULL;
+    char *child = item;
+    char *parent;
+    memcpy(&parent, item + node_parent_offset, ptr_size);
     while (parent) {
-        if (parent->left == child) {
-            parent->balance--;
+        char *parent_left;
+        memcpy(&parent_left, parent + node_left_child_offset, ptr_size);
+        if (parent_left == child) {
+            parent[0]--;
         } else {
-            parent->balance++;
+            parent[0]++;
         }
         /* If balance is zero after modification, then the tree is balanced. */
-        if (parent->balance == 0) {
+        if (parent[0] == 0) {
             return;
         }
         /* Must re-balance if not in {-1, 0, 1} */
-        if (parent->balance > 1 || parent->balance < -1) {
+        if (parent[0] > 1 || parent[0] < -1) {
             /* After one repair, the tree is balanced. */
             set_repair(me, parent, child, grand_child);
             return;
         }
         grand_child = child;
         child = parent;
-        parent = parent->parent;
+        memcpy(&parent, parent + node_parent_offset, ptr_size);
     }
 }
 
 /*
  * Creates and allocates a node.
  */
-static struct node *set_create_node(set me,
-                                    const void *const data,
-                                    struct node *const parent)
+static char *set_create_node(set me, const void *const data, char *const parent)
 {
-    struct node *const insert = malloc(sizeof(struct node));
+    char *insert = malloc(1 + 3 * ptr_size + me->key_size);
     if (!insert) {
         return NULL;
     }
-    insert->parent = parent;
-    insert->balance = 0;
-    insert->key = malloc(me->key_size);
-    if (!insert->key) {
-        free(insert);
-        return NULL;
-    }
-    memcpy(insert->key, data, me->key_size);
-    insert->left = NULL;
-    insert->right = NULL;
+    insert[0] = 0;
+    memcpy(insert + node_parent_offset, &parent, ptr_size);
+    memset(insert + node_left_child_offset, 0, ptr_size);
+    memset(insert + node_right_child_offset, 0, ptr_size);
+    memcpy(insert + node_key_offset, data, me->key_size);
     me->size++;
     return insert;
 }
@@ -320,9 +304,9 @@ static struct node *set_create_node(set me,
  */
 int set_put(set me, void *const key)
 {
-    struct node *traverse;
+    char *traverse;
     if (!me->root) {
-        struct node *insert = set_create_node(me, key, NULL);
+        char *insert = set_create_node(me, key, NULL);
         if (!insert) {
             return -ENOMEM;
         }
@@ -331,28 +315,33 @@ int set_put(set me, void *const key)
     }
     traverse = me->root;
     for (;;) {
-        const int compare = me->comparator(key, traverse->key);
+        const int compare = me->comparator(key, traverse + node_key_offset);
         if (compare < 0) {
-            if (traverse->left) {
-                traverse = traverse->left;
+            char *traverse_left;
+            memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+            if (traverse_left) {
+                traverse = traverse_left;
             } else {
-                struct node *insert = set_create_node(me, key, traverse);
+                char *insert = set_create_node(me, key, traverse);
                 if (!insert) {
                     return -ENOMEM;
                 }
-                traverse->left = insert;
+                memcpy(traverse + node_left_child_offset, &insert, ptr_size);
                 set_insert_balance(me, insert);
                 return 0;
             }
         } else if (compare > 0) {
-            if (traverse->right) {
-                traverse = traverse->right;
+            char *traverse_right;
+            memcpy(&traverse_right, traverse + node_right_child_offset,
+                   ptr_size);
+            if (traverse_right) {
+                traverse = traverse_right;
             } else {
-                struct node *insert = set_create_node(me, key, traverse);
+                char *insert = set_create_node(me, key, traverse);
                 if (!insert) {
                     return -ENOMEM;
                 }
-                traverse->right = insert;
+                memcpy(traverse + node_right_child_offset, &insert, ptr_size);
                 set_insert_balance(me, insert);
                 return 0;
             }
@@ -365,23 +354,28 @@ int set_put(set me, void *const key)
 /*
  * If a match occurs, returns the match. Else, returns NULL.
  */
-static struct node *set_equal_match(set me, const void *const key)
+static char *set_equal_match(set me, const void *const key)
 {
-    struct node *traverse = me->root;
+    char *traverse = me->root;
     if (!traverse) {
         return NULL;
     }
     for (;;) {
-        const int compare = me->comparator(key, traverse->key);
+        const int compare = me->comparator(key, traverse + node_key_offset);
         if (compare < 0) {
-            if (traverse->left) {
-                traverse = traverse->left;
+            char *traverse_left;
+            memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+            if (traverse_left) {
+                traverse = traverse_left;
             } else {
                 return NULL;
             }
         } else if (compare > 0) {
-            if (traverse->right) {
-                traverse = traverse->right;
+            char *traverse_right;
+            memcpy(&traverse_right, traverse + node_right_child_offset,
+                   ptr_size);
+            if (traverse_right) {
+                traverse = traverse_right;
             } else {
                 return NULL;
             }
@@ -411,45 +405,55 @@ int set_contains(set me, void *const key)
 /*
  * Repairs the AVL tree by pivoting on an item.
  */
-static struct node *set_repair_pivot(set me,
-                                     struct node *const item,
-                                     const int is_left_pivot)
+static char *set_repair_pivot(set me, char *const item, const int is_left_pivot)
 {
-    struct node *const child = is_left_pivot ? item->right : item->left;
-    struct node *const grand_child =
-            child->balance == 1 ? child->right : child->left;
+    char *child;
+    char *grand_child;
+    char *item_right;
+    char *item_left;
+    char *child_right;
+    char *child_left;
+    memcpy(&item_right, item + node_right_child_offset, ptr_size);
+    memcpy(&item_left, item + node_left_child_offset, ptr_size);
+    child = is_left_pivot ? item_right : item_left;
+    memcpy(&child_right, child + node_right_child_offset, ptr_size);
+    memcpy(&child_left, child + node_left_child_offset, ptr_size);
+    grand_child = child[0] == 1 ? child_right : child_left;
     return set_repair(me, item, child, grand_child);
 }
 
 /*
  * Goes back up the tree repairing it along the way.
  */
-static void set_trace_ancestors(set me, struct node *item)
+static void set_trace_ancestors(set me, char *item)
 {
-    struct node *child = item;
-    struct node *parent = item->parent;
+    char *child = item;
+    char *parent;
+    memcpy(&parent, item + node_parent_offset, ptr_size);
     while (parent) {
-        if (parent->left == child) {
-            parent->balance++;
+        char *parent_left;
+        memcpy(&parent_left, parent + node_left_child_offset, ptr_size);
+        if (parent_left == child) {
+            parent[0]++;
         } else {
-            parent->balance--;
+            parent[0]--;
         }
         /* The tree is balanced if balance is -1 or +1 after modification. */
-        if (parent->balance == -1 || parent->balance == 1) {
+        if (parent[0] == -1 || parent[0] == 1) {
             return;
         }
         /* Must re-balance if not in {-1, 0, 1} */
-        if (parent->balance > 1 || parent->balance < -1) {
-            child = set_repair_pivot(me, parent, parent->left == child);
-            parent = child->parent;
-            /* If balance is -1 or +1 after modification or the parent is */
-            /* NULL, then the tree is balanced. */
-            if (!parent || child->balance == -1 || child->balance == 1) {
+        if (parent[0] > 1 || parent[0] < -1) {
+            child = set_repair_pivot(me, parent, parent_left == child);
+            memcpy(&parent, child + node_parent_offset, ptr_size);
+            /* If balance is -1 or +1 after modification or   */
+            /* the parent is NULL, then the tree is balanced. */
+            if (!parent || child[0] == -1 || child[0] == 1) {
                 return;
             }
         } else {
             child = parent;
-            parent = parent->parent;
+            memcpy(&parent, parent + node_parent_offset, ptr_size);
         }
     }
 }
@@ -457,23 +461,23 @@ static void set_trace_ancestors(set me, struct node *item)
 /*
  * Balances the AVL tree on deletion.
  */
-static void set_delete_balance(set me,
-                               struct node *item,
-                               const int is_left_deleted)
+static void set_delete_balance(set me, char *item, const int is_left_deleted)
 {
     if (is_left_deleted) {
-        item->balance++;
+        item[0]++;
     } else {
-        item->balance--;
+        item[0]--;
     }
     /* If balance is -1 or +1 after modification, then the tree is balanced. */
-    if (item->balance == -1 || item->balance == 1) {
+    if (item[0] == -1 || item[0] == 1) {
         return;
     }
     /* Must re-balance if not in {-1, 0, 1} */
-    if (item->balance > 1 || item->balance < -1) {
+    if (item[0] > 1 || item[0] < -1) {
+        char *item_parent;
         item = set_repair_pivot(me, item, is_left_deleted);
-        if (!item->parent || item->balance == -1 || item->balance == 1) {
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        if (!item_parent || item[0] == -1 || item[0] == 1) {
             return;
         }
     }
@@ -483,101 +487,150 @@ static void set_delete_balance(set me,
 /*
  * Removes traverse when it has no children.
  */
-static void set_remove_no_children(set me, const struct node *const traverse)
+static void set_remove_no_children(set me, const char *const traverse)
 {
-    struct node *const parent = traverse->parent;
+    char *traverse_parent;
+    char *traverse_parent_left;
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
     /* If no parent and no children, then the only node is traverse. */
-    if (!parent) {
+    if (!traverse_parent) {
         me->root = NULL;
         return;
     }
+    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+           ptr_size);
     /* No re-reference needed since traverse has no children. */
-    if (parent->left == traverse) {
-        parent->left = NULL;
-        set_delete_balance(me, parent, 1);
+    if (traverse_parent_left == traverse) {
+        memset(traverse_parent + node_left_child_offset, 0, ptr_size);
+        set_delete_balance(me, traverse_parent, 1);
     } else {
-        parent->right = NULL;
-        set_delete_balance(me, parent, 0);
+        memset(traverse_parent + node_right_child_offset, 0, ptr_size);
+        set_delete_balance(me, traverse_parent, 0);
     }
 }
 
 /*
  * Removes traverse when it has one child.
  */
-static void set_remove_one_child(set me, const struct node *const traverse)
+static void set_remove_one_child(set me, const char *const traverse)
 {
-    struct node *const parent = traverse->parent;
+    char *traverse_parent;
+    char *traverse_left;
+    char *traverse_right;
+    char *traverse_parent_left;
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
+    memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
     /* If no parent, make the child of traverse the new root. */
-    if (!parent) {
-        if (traverse->left) {
-            traverse->left->parent = NULL;
-            me->root = traverse->left;
+    if (!traverse_parent) {
+        if (traverse_left) {
+            memset(traverse_left + node_parent_offset, 0, ptr_size);
+            me->root = traverse_left;
         } else {
-            traverse->right->parent = NULL;
-            me->root = traverse->right;
+            memset(traverse_right + node_parent_offset, 0, ptr_size);
+            me->root = traverse_right;
         }
         return;
     }
+    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+           ptr_size);
     /* The parent of traverse now references the child of traverse. */
-    if (parent->left == traverse) {
-        if (traverse->left) {
-            parent->left = traverse->left;
-            traverse->left->parent = parent;
+    if (traverse_parent_left == traverse) {
+        if (traverse_left) {
+            memcpy(traverse_parent + node_left_child_offset, &traverse_left,
+                   ptr_size);
+            memcpy(traverse_left + node_parent_offset, &traverse_parent,
+                   ptr_size);
         } else {
-            parent->left = traverse->right;
-            traverse->right->parent = parent;
+            memcpy(traverse_parent + node_left_child_offset, &traverse_right,
+                   ptr_size);
+            memcpy(traverse_right + node_parent_offset, &traverse_parent,
+                   ptr_size);
         }
-        set_delete_balance(me, parent, 1);
+        set_delete_balance(me, traverse_parent, 1);
     } else {
-        if (traverse->left) {
-            parent->right = traverse->left;
-            traverse->left->parent = parent;
+        if (traverse_left) {
+            memcpy(traverse_parent + node_right_child_offset, &traverse_left,
+                   ptr_size);
+            memcpy(traverse_left + node_parent_offset, &traverse_parent,
+                   ptr_size);
         } else {
-            parent->right = traverse->right;
-            traverse->right->parent = parent;
+            memcpy(traverse_parent + node_right_child_offset, &traverse_right,
+                   ptr_size);
+            memcpy(traverse_right + node_parent_offset, &traverse_parent,
+                   ptr_size);
         }
-        set_delete_balance(me, parent, 0);
+        set_delete_balance(me, traverse_parent, 0);
     }
 }
 
 /*
  * Removes traverse when it has two children.
  */
-static void set_remove_two_children(set me, const struct node *const traverse)
+static void set_remove_two_children(set me, const char *const traverse)
 {
-    struct node *item;
-    struct node *parent;
-    const int is_left_deleted = traverse->right->left != NULL;
+    char *item;
+    char *item_parent;
+    char *parent;
+    char *traverse_parent;
+    char *traverse_parent_left;
+    char *traverse_right;
+    char *traverse_right_left;
+    int is_left_deleted;
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
+    memcpy(&traverse_right_left, traverse_right + node_left_child_offset,
+           ptr_size);
+    is_left_deleted = traverse_right_left != NULL;
     if (!is_left_deleted) {
-        item = traverse->right;
+        char *item_left;
+        item = traverse_right;
         parent = item;
-        item->balance = traverse->balance;
-        item->parent = traverse->parent;
-        item->left = traverse->left;
-        item->left->parent = item;
+        item[0] = traverse[0];
+        memcpy(item + node_parent_offset, traverse + node_parent_offset,
+               ptr_size);
+        memcpy(item + node_left_child_offset, traverse + node_left_child_offset,
+               ptr_size);
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
+        memcpy(item_left + node_parent_offset, &item, ptr_size);
     } else {
-        item = traverse->right->left;
-        while (item->left) {
-            item = item->left;
+        char *item_left;
+        char *item_right;
+        item = traverse_right_left;
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
+        while (item_left) {
+            item = item_left;
+            memcpy(&item_left, item + node_left_child_offset, ptr_size);
         }
-        parent = item->parent;
-        item->balance = traverse->balance;
-        item->parent->left = item->right;
-        if (item->right) {
-            item->right->parent = item->parent;
+        memcpy(&parent, item + node_parent_offset, ptr_size);
+        item[0] = traverse[0];
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        memcpy(item_parent + node_left_child_offset,
+               item + node_right_child_offset, ptr_size);
+        memcpy(&item_right, item + node_right_child_offset, ptr_size);
+        if (item_right) {
+            memcpy(item_right + node_parent_offset, item + node_parent_offset,
+                   ptr_size);
         }
-        item->left = traverse->left;
-        item->left->parent = item;
-        item->right = traverse->right;
-        item->right->parent = item;
-        item->parent = traverse->parent;
+        memcpy(item + node_left_child_offset, traverse + node_left_child_offset,
+               ptr_size);
+        memcpy(item_left + node_parent_offset, &item, ptr_size);
+        memcpy(item + node_right_child_offset,
+               traverse + node_right_child_offset, ptr_size);
+        memcpy(&item_right, item + node_right_child_offset, ptr_size);
+        memcpy(item_right + node_parent_offset, &item, ptr_size);
+        memcpy(item + node_parent_offset, traverse + node_parent_offset,
+               ptr_size);
     }
-    if (!traverse->parent) {
+    memcpy(&item_parent, item + node_parent_offset, ptr_size);
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
+    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+           ptr_size);
+    if (!traverse_parent) {
         me->root = item;
-    } else if (traverse->parent->left == traverse) {
-        item->parent->left = item;
+    } else if (traverse_parent_left == traverse) {
+        memcpy(item_parent + node_left_child_offset, &item, ptr_size);
     } else {
-        item->parent->right = item;
+        memcpy(item_parent + node_right_child_offset, &item, ptr_size);
     }
     set_delete_balance(me, parent, is_left_deleted);
 }
@@ -585,16 +638,19 @@ static void set_remove_two_children(set me, const struct node *const traverse)
 /*
  * Removes the element from the set.
  */
-static void set_remove_element(set me, struct node *const traverse)
+static void set_remove_element(set me, char *const traverse)
 {
-    if (!traverse->left && !traverse->right) {
+    char *traverse_left;
+    char *traverse_right;
+    memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
+    if (!traverse_left && !traverse_right) {
         set_remove_no_children(me, traverse);
-    } else if (!traverse->left || !traverse->right) {
+    } else if (!traverse_left || !traverse_right) {
         set_remove_one_child(me, traverse);
     } else {
         set_remove_two_children(me, traverse);
     }
-    free(traverse->key);
     free(traverse);
     me->size--;
 }
@@ -613,7 +669,7 @@ static void set_remove_element(set me, struct node *const traverse)
  */
 int set_remove(set me, void *const key)
 {
-    struct node *const traverse = set_equal_match(me, key);
+    char *const traverse = set_equal_match(me, key);
     if (!traverse) {
         return 0;
     }

--- a/tst/test_set.c
+++ b/tst/test_set.c
@@ -1,3 +1,4 @@
+#include <memory.h>
 #include "test.h"
 #include "../src/include/set.h"
 
@@ -5,62 +6,73 @@
  * Include this struct to verify the tree.
  */
 struct internal_set {
+    size_t size;
     size_t key_size;
     int (*comparator)(const void *const one, const void *const two);
-    int size;
-    struct node *root;
+    char *root;
 };
 
 /*
  * Include this struct to verify the tree.
  */
-struct node {
-    struct node *parent;
-    int balance;
-    void *key;
-    struct node *left;
-    struct node *right;
-};
+static const size_t ptr_size = sizeof(char *);
+/* Node balance is always the first byte (at index 0). */
+static const size_t node_parent_offset = sizeof(signed char);
+static const size_t node_left_child_offset = 1 + sizeof(char *);
+static const size_t node_right_child_offset = 1 + 2 * sizeof(char *);
+static const size_t node_key_offset = 1 + 3 * sizeof(char *);
 
 /*
  * Verifies that the AVL tree rules are followed. The balance factor of an item
  * must be the right height minus the left height. Also, the left key must be
  * less than the right key.
  */
-static int set_verify_recursive(struct node *const item)
+static int set_verify_recursive(char *const item)
 {
     int left;
     int right;
     int max;
+    char *item_left;
+    char *item_right;
     if (!item) {
         return 0;
     }
-    left = set_verify_recursive(item->left);
-    right = set_verify_recursive(item->right);
+    memcpy(&item_left, item + node_left_child_offset, ptr_size);
+    memcpy(&item_right, item + node_right_child_offset, ptr_size);
+    left = set_verify_recursive(item_left);
+    right = set_verify_recursive(item_right);
     max = left > right ? left : right;
-    assert(right - left == item->balance);
-    if (item->left && item->right) {
-        const int left_val = *(int *) item->left->key;
-        const int right_val = *(int *) item->right->key;
+    assert(right - left == item[0]);
+    if (item_left && item_right) {
+        const int left_val = *(int *) (item_left + node_key_offset);
+        const int right_val = *(int *) (item_right + node_key_offset);
         assert(left_val < right_val);
     }
-    if (item->left) {
-        assert(item->left->parent == item);
-        assert(item->left->parent->key == item->key);
+    if (item_left) {
+        char *item_left_parent;
+        memcpy(&item_left_parent, item_left + node_parent_offset, ptr_size);
+        assert(item_left_parent == item);
+        assert(item_left_parent + node_key_offset == item + node_key_offset);
     }
-    if (item->right) {
-        assert(item->right->parent == item);
-        assert(item->right->parent->key == item->key);
+    if (item_right) {
+        char *item_right_parent;
+        memcpy(&item_right_parent, item_right + node_parent_offset, ptr_size);
+        assert(item_right_parent == item);
+        assert(item_right_parent + node_key_offset == item + node_key_offset);
     }
     return max + 1;
 }
 
-static size_t set_compute_size(struct node *const item)
+static size_t set_compute_size(char *const item)
 {
+    char *left;
+    char *right;
     if (!item) {
         return 0;
     }
-    return 1 + set_compute_size(item->left) + set_compute_size(item->right);
+    memcpy(&left, item + node_left_child_offset, ptr_size);
+    memcpy(&right, item + node_right_child_offset, ptr_size);
+    return 1 + set_compute_size(left) + set_compute_size(right);
 }
 
 static void set_verify(set me)
@@ -475,9 +487,6 @@ static void test_put_root_out_of_memory(set me)
     int key = 2;
     fail_malloc = 1;
     assert(set_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(set_put(me, &key) == -ENOMEM);
 }
 #endif
 
@@ -487,9 +496,6 @@ static void test_put_on_left_out_of_memory(set me)
     int key = 1;
     fail_malloc = 1;
     assert(set_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(set_put(me, &key) == -ENOMEM);
 }
 #endif
 
@@ -498,9 +504,6 @@ static void test_put_on_right_out_of_memory(set me)
 {
     int key = 3;
     fail_malloc = 1;
-    assert(set_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
     assert(set_put(me, &key) == -ENOMEM);
 }
 #endif

--- a/tst/test_set.c
+++ b/tst/test_set.c
@@ -55,7 +55,7 @@ static int set_verify_recursive(struct node *const item)
     return max + 1;
 }
 
-static int set_compute_size(struct node *const item)
+static size_t set_compute_size(struct node *const item)
 {
     if (!item) {
         return 0;
@@ -85,7 +85,7 @@ static void test_invalid_init(void)
 static void mutation_order(set me, const int *const arr, const int size)
 {
     int i;
-    int actual_size = 0;
+    size_t actual_size = 0;
     assert(set_is_empty(me));
     for (i = 0; i < size; i++) {
         int num = arr[i];
@@ -370,7 +370,7 @@ static void test_contains(void)
 
 static void test_stress_add(void)
 {
-    int count = 0;
+    size_t count = 0;
     int flip = 0;
     int i;
     set me = set_init(sizeof(int), compare_int);


### PR DESCRIPTION
Using this as a test:
```
set me = set_init(sizeof(int), compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        set_put(me, &i);
    }
    for (i = 0; i < 1000000; i++) {
        count += set_contains(me, &i);
    }
    printf("%d\n", count);
    set_destroy(me);
```
The old version took 0.67s and the new version takes 0.47s. This is an efficiency improvement of 30%.