### PR TITLE
Reduce calls to malloc in multiset

### DIFF
--- a/containers.h
+++ b/containers.h
@@ -385,12 +385,12 @@ multiset multiset_init(size_t key_size,
                                          const void *const two));
 
 /* Capacity */
-int multiset_size(multiset me);
+size_t multiset_size(multiset me);
 int multiset_is_empty(multiset me);
 
 /* Accessing */
 int multiset_put(multiset me, void *key);
-int multiset_count(multiset me, void *key);
+size_t multiset_count(multiset me, void *key);
 int multiset_contains(multiset me, void *key);
 int multiset_remove(multiset me, void *key);
 int multiset_remove_all(multiset me, void *key);

--- a/src/include/multiset.h
+++ b/src/include/multiset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,12 +37,12 @@ multiset multiset_init(size_t key_size,
                                          const void *const two));
 
 /* Capacity */
-int multiset_size(multiset me);
+size_t multiset_size(multiset me);
 int multiset_is_empty(multiset me);
 
 /* Accessing */
 int multiset_put(multiset me, void *key);
-int multiset_count(multiset me, void *key);
+size_t multiset_count(multiset me, void *key);
 int multiset_contains(multiset me, void *key);
 int multiset_remove(multiset me, void *key);
 int multiset_remove_all(multiset me, void *key);

--- a/tst/test_multiset.c
+++ b/tst/test_multiset.c
@@ -489,6 +489,13 @@ static void test_multiple_operations(void)
     assert(multiset_count(me, &key) == 1);
     key = 5;
     assert(multiset_count(me, &key) == 2);
+    assert(multiset_size(me) == 3);
+    assert(multiset_remove(me, &key));
+    assert(multiset_count(me, &key) == 1);
+    assert(multiset_size(me) == 2);
+    assert(multiset_remove(me, &key));
+    assert(multiset_count(me, &key) == 0);
+    assert(multiset_size(me) == 1);
     multiset_remove_all(me, &key);
     assert(multiset_size(me) == 1);
     key = 7;

--- a/tst/test_multiset.c
+++ b/tst/test_multiset.c
@@ -1,68 +1,82 @@
+#include <memory.h>
 #include "test.h"
 #include "../src/include/multiset.h"
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
 struct internal_multiset {
+    size_t size;
     size_t key_size;
     int (*comparator)(const void *const one, const void *const two);
-    int size;
-    struct node *root;
+    char *root;
 };
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
-struct node {
-    int count;
-    struct node *parent;
-    int balance;
-    void *key;
-    struct node *left;
-    struct node *right;
-};
+static const size_t ptr_size = sizeof(char *);
+/* static const size_t count_size = sizeof(size_t); */
+/* Node balance is always the first byte (at index 0). */
+/* static const size_t node_count_offset = sizeof(signed char); */
+static const size_t node_parent_offset = 1 + sizeof(size_t);
+static const size_t node_left_child_offset =
+        1 + sizeof(size_t) + sizeof(char *);
+static const size_t node_right_child_offset =
+        1 + sizeof(size_t) + 2 * sizeof(char *);
+static const size_t node_key_offset = 1 + sizeof(size_t) + 3 * sizeof(char *);
 
 /*
  * Verifies that the AVL tree rules are followed. The balance factor of an item
  * must be the right height minus the left height. Also, the left key must be
  * less than the right key.
  */
-static int multiset_verify_recursive(struct node *const item)
+static int multiset_verify_recursive(char *const item)
 {
     int left;
     int right;
     int max;
+    char *item_left;
+    char *item_right;
     if (!item) {
         return 0;
     }
-    left = multiset_verify_recursive(item->left);
-    right = multiset_verify_recursive(item->right);
+    memcpy(&item_left, item + node_left_child_offset, ptr_size);
+    memcpy(&item_right, item + node_right_child_offset, ptr_size);
+    left = multiset_verify_recursive(item_left);
+    right = multiset_verify_recursive(item_right);
     max = left > right ? left : right;
-    assert(right - left == item->balance);
-    if (item->left && item->right) {
-        const int left_val = *(int *) item->left->key;
-        const int right_val = *(int *) item->right->key;
+    assert(right - left == item[0]);
+    if (item_left && item_right) {
+        const int left_val = *(int *) (item_left + node_key_offset);
+        const int right_val = *(int *) (item_right + node_key_offset);
         assert(left_val < right_val);
     }
-    if (item->left) {
-        assert(item->left->parent == item);
-        assert(item->left->parent->key == item->key);
+    if (item_left) {
+        char *item_left_parent;
+        memcpy(&item_left_parent, item_left + node_parent_offset, ptr_size);
+        assert(item_left_parent == item);
+        assert(item_left_parent + node_key_offset == item + node_key_offset);
     }
-    if (item->right) {
-        assert(item->right->parent == item);
-        assert(item->right->parent->key == item->key);
+    if (item_right) {
+        char *item_right_parent;
+        memcpy(&item_right_parent, item_right + node_parent_offset, ptr_size);
+        assert(item_right_parent == item);
+        assert(item_right_parent + node_key_offset == item + node_key_offset);
     }
     return max + 1;
 }
 
-static int multiset_compute_size(struct node *const item)
+static size_t multiset_compute_size(char *const item)
 {
+    char *left;
+    char *right;
     if (!item) {
         return 0;
     }
-    return 1 + multiset_compute_size(item->left) +
-           multiset_compute_size(item->right);
+    memcpy(&left, item + node_left_child_offset, ptr_size);
+    memcpy(&right, item + node_right_child_offset, ptr_size);
+    return 1 + multiset_compute_size(left) + multiset_compute_size(right);
 }
 
 static void multiset_verify(multiset me)
@@ -87,7 +101,7 @@ static void test_invalid_init(void)
 static void mutation_order(multiset me, const int *const arr, const int size)
 {
     int i;
-    int actual_size = 0;
+    size_t actual_size = 0;
     assert(multiset_is_empty(me));
     for (i = 0; i < size; i++) {
         int num = arr[i];
@@ -372,7 +386,7 @@ static void test_contains(void)
 
 static void test_stress_add(void)
 {
-    int count = 0;
+    size_t count = 0;
     int flip = 0;
     int i;
     multiset me = multiset_init(sizeof(int), compare_int);
@@ -497,9 +511,6 @@ static void test_put_root_out_of_memory(multiset me)
     int key = 2;
     fail_malloc = 1;
     assert(multiset_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(multiset_put(me, &key) == -ENOMEM);
 }
 #endif
 
@@ -509,9 +520,6 @@ static void test_put_on_left_out_of_memory(multiset me)
     int key = 1;
     fail_malloc = 1;
     assert(multiset_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(multiset_put(me, &key) == -ENOMEM);
 }
 #endif
 
@@ -520,9 +528,6 @@ static void test_put_on_right_out_of_memory(multiset me)
 {
     int key = 3;
     fail_malloc = 1;
-    assert(multiset_put(me, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
     assert(multiset_put(me, &key) == -ENOMEM);
 }
 #endif

--- a/tst/test_set.c
+++ b/tst/test_set.c
@@ -3,7 +3,7 @@
 #include "../src/include/set.h"
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
 struct internal_set {
     size_t size;
@@ -13,7 +13,7 @@ struct internal_set {
 };
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
 static const size_t ptr_size = sizeof(char *);
 /* Node balance is always the first byte (at index 0). */


### PR DESCRIPTION
Using this to test:
```
    multiset me = multiset_init(sizeof(int), compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        multiset_put(me, &i);
    }
    for (i = 0; i < 1000000; i++) {
        count += multiset_contains(me, &i);
    }
    printf("%d\n", count);
    multiset_destroy(me);
```
The old version would run in 0.68s and the new version runs in 0.50s. This is an improvement of 30%.