### PR TITLE
Reduce calls to malloc in map

### DIFF
--- a/containers.h
+++ b/containers.h
@@ -75,12 +75,11 @@ unordered_map unordered_map_destroy(unordered_map me);
 typedef struct internal_map *map;
 
 /* Starting */
-map map_init(size_t key_size,
-             size_t value_size,
+map map_init(size_t key_size, size_t value_size,
              int (*comparator)(const void *const one, const void *const two));
 
 /* Capacity */
-int map_size(map me);
+size_t map_size(map me);
 int map_is_empty(map me);
 
 /* Accessing */

--- a/src/include/map.h
+++ b/src/include/map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,12 +32,11 @@
 typedef struct internal_map *map;
 
 /* Starting */
-map map_init(size_t key_size,
-             size_t value_size,
+map map_init(size_t key_size, size_t value_size,
              int (*comparator)(const void *const one, const void *const two));
 
 /* Capacity */
-int map_size(map me);
+size_t map_size(map me);
 int map_is_empty(map me);
 
 /* Accessing */

--- a/src/map.c
+++ b/src/map.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Bailey Thompson
+ * Copyright (c) 2017-2020 Bailey Thompson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,21 +25,20 @@
 #include "include/map.h"
 
 struct internal_map {
+    size_t size;
     size_t key_size;
     size_t value_size;
     int (*comparator)(const void *const one, const void *const two);
-    int size;
-    struct node *root;
+    char *root;
 };
 
-struct node {
-    struct node *parent;
-    int balance;
-    void *key;
-    void *value;
-    struct node *left;
-    struct node *right;
-};
+static const size_t ptr_size = sizeof(char *);
+/* Node balance is always the first byte (at index 0). */
+static const size_t node_parent_offset = sizeof(signed char);
+static const size_t node_left_child_offset = 1 + sizeof(char *);
+static const size_t node_right_child_offset = 1 + 2 * sizeof(char *);
+static const size_t node_key_offset = 1 + 3 * sizeof(char *);
+/* Assume the value starts right after the key ends. */
 
 /**
  * Initializes a map.
@@ -53,8 +52,7 @@ struct node {
  *         initialized due to either invalid input arguments or memory
  *         allocation error
  */
-map map_init(const size_t key_size,
-             const size_t value_size,
+map map_init(const size_t key_size, const size_t value_size,
              int (*const comparator)(const void *const, const void *const))
 {
     struct internal_map *init;
@@ -65,10 +63,10 @@ map map_init(const size_t key_size,
     if (!init) {
         return NULL;
     }
+    init->size = 0;
     init->key_size = key_size;
     init->value_size = value_size;
     init->comparator = comparator;
-    init->size = 0;
     init->root = NULL;
     return init;
 }
@@ -80,7 +78,7 @@ map map_init(const size_t key_size,
  *
  * @return the size of the map
  */
-int map_size(map me)
+size_t map_size(map me)
 {
     return me->size;
 }
@@ -100,70 +98,69 @@ int map_is_empty(map me)
 /*
  * Resets the parent reference.
  */
-static void map_reference_parent(map me,
-                                 struct node *const parent,
-                                 struct node *const child)
+static void map_reference_parent(map me, char *const parent, char *const child)
 {
-    child->parent = parent->parent;
-    if (!parent->parent) {
+    char *grand_parent;
+    char *grand_parent_left_child;
+    memcpy(child + node_parent_offset, parent + node_parent_offset, ptr_size);
+    memcpy(&grand_parent, parent + node_parent_offset, ptr_size);
+    if (!grand_parent) {
         me->root = child;
-    } else if (parent->parent->left == parent) {
-        parent->parent->left = child;
+        return;
+    }
+    memcpy(&grand_parent_left_child, grand_parent + node_left_child_offset,
+           ptr_size);
+    if (grand_parent_left_child == parent) {
+        memcpy(grand_parent + node_left_child_offset, &child, ptr_size);
     } else {
-        parent->parent->right = child;
+        memcpy(grand_parent + node_right_child_offset, &child, ptr_size);
     }
 }
 
 /*
  * Rotates the AVL tree to the left.
  */
-static void map_rotate_left(map me,
-                            struct node *const parent,
-                            struct node *const child)
+static void map_rotate_left(map me, char *const parent, char *const child)
 {
-    struct node *grand_child;
+    char *left_grand_child;
     map_reference_parent(me, parent, child);
-    grand_child = child->left;
-    if (grand_child) {
-        grand_child->parent = parent;
+    memcpy(&left_grand_child, child + node_left_child_offset, ptr_size);
+    if (left_grand_child) {
+        memcpy(left_grand_child + node_parent_offset, &parent, ptr_size);
     }
-    parent->parent = child;
-    parent->right = grand_child;
-    child->left = parent;
+    memcpy(parent + node_parent_offset, &child, ptr_size);
+    memcpy(parent + node_right_child_offset, &left_grand_child, ptr_size);
+    memcpy(child + node_left_child_offset, &parent, ptr_size);
 }
 
 /*
  * Rotates the AVL tree to the right.
  */
-static void map_rotate_right(map me,
-                             struct node *const parent,
-                             struct node *const child)
+static void map_rotate_right(map me, char *const parent, char *const child)
 {
-    struct node *grand_child;
+    char *right_grand_child;
     map_reference_parent(me, parent, child);
-    grand_child = child->right;
-    if (grand_child) {
-        grand_child->parent = parent;
+    memcpy(&right_grand_child, child + node_right_child_offset, ptr_size);
+    if (right_grand_child) {
+        memcpy(right_grand_child + node_parent_offset, &parent, ptr_size);
     }
-    parent->parent = child;
-    parent->left = grand_child;
-    child->right = parent;
+    memcpy(parent + node_parent_offset, &child, ptr_size);
+    memcpy(parent + node_left_child_offset, &right_grand_child, ptr_size);
+    memcpy(child + node_right_child_offset, &parent, ptr_size);
 }
 
 /*
  * Performs a left repair.
  */
-static struct node *map_repair_left(map me,
-                                    struct node *const parent,
-                                    struct node *const child)
+static char *map_repair_left(map me, char *const parent, char *const child)
 {
     map_rotate_left(me, parent, child);
-    if (child->balance == 0) {
-        parent->balance = 1;
-        child->balance = -1;
+    if (child[0] == 0) {
+        parent[0] = 1;
+        child[0] = -1;
     } else {
-        parent->balance = 0;
-        child->balance = 0;
+        parent[0] = 0;
+        child[0] = 0;
     }
     return child;
 }
@@ -171,17 +168,15 @@ static struct node *map_repair_left(map me,
 /*
  * Performs a right repair.
  */
-static struct node *map_repair_right(map me,
-                                     struct node *const parent,
-                                     struct node *const child)
+static char *map_repair_right(map me, char *const parent, char *const child)
 {
     map_rotate_right(me, parent, child);
-    if (child->balance == 0) {
-        parent->balance = -1;
-        child->balance = 1;
+    if (child[0] == 0) {
+        parent[0] = -1;
+        child[0] = 1;
     } else {
-        parent->balance = 0;
-        child->balance = 0;
+        parent[0] = 0;
+        child[0] = 0;
     }
     return child;
 }
@@ -189,48 +184,44 @@ static struct node *map_repair_right(map me,
 /*
  * Performs a left-right repair.
  */
-static struct node *map_repair_left_right(map me,
-                                          struct node *const parent,
-                                          struct node *const child,
-                                          struct node *const grand_child)
+static char *map_repair_left_right(map me, char *const parent,
+                                   char *const child, char *const grand_child)
 {
     map_rotate_left(me, child, grand_child);
     map_rotate_right(me, parent, grand_child);
-    if (grand_child->balance == 1) {
-        parent->balance = 0;
-        child->balance = -1;
-    } else if (grand_child->balance == 0) {
-        parent->balance = 0;
-        child->balance = 0;
+    if (grand_child[0] == 1) {
+        parent[0] = 0;
+        child[0] = -1;
+    } else if (grand_child[0] == 0) {
+        parent[0] = 0;
+        child[0] = 0;
     } else {
-        parent->balance = 1;
-        child->balance = 0;
+        parent[0] = 1;
+        child[0] = 0;
     }
-    grand_child->balance = 0;
+    grand_child[0] = 0;
     return grand_child;
 }
 
 /*
  * Performs a right-left repair.
  */
-static struct node *map_repair_right_left(map me,
-                                          struct node *const parent,
-                                          struct node *const child,
-                                          struct node *const grand_child)
+static char *map_repair_right_left(map me, char *const parent,
+                                   char *const child, char *const grand_child)
 {
     map_rotate_right(me, child, grand_child);
     map_rotate_left(me, parent, grand_child);
-    if (grand_child->balance == 1) {
-        parent->balance = -1;
-        child->balance = 0;
-    } else if (grand_child->balance == 0) {
-        parent->balance = 0;
-        child->balance = 0;
+    if (grand_child[0] == 1) {
+        parent[0] = -1;
+        child[0] = 0;
+    } else if (grand_child[0] == 0) {
+        parent[0] = 0;
+        child[0] = 0;
     } else {
-        parent->balance = 0;
-        child->balance = 1;
+        parent[0] = 0;
+        child[0] = 1;
     }
-    grand_child->balance = 0;
+    grand_child[0] = 0;
     return grand_child;
 }
 
@@ -238,18 +229,16 @@ static struct node *map_repair_right_left(map me,
  * Repairs the AVL tree on insert. The only possible values of parent->balance
  * are {-2, 2} and the only possible values of child->balance are {-1, 0, 1}.
  */
-static struct node *map_repair(map me,
-                               struct node *const parent,
-                               struct node *const child,
-                               struct node *const grand_child)
+static char *map_repair(map me, char *const parent, char *const child,
+                        char *const grand_child)
 {
-    if (parent->balance == 2) {
-        if (child->balance == -1) {
+    if (parent[0] == 2) {
+        if (child[0] == -1) {
             return map_repair_right_left(me, parent, child, grand_child);
         }
         return map_repair_left(me, parent, child);
     }
-    if (child->balance == 1) {
+    if (child[0] == 1) {
         return map_repair_left_right(me, parent, child, grand_child);
     }
     return map_repair_right(me, parent, child);
@@ -258,62 +247,52 @@ static struct node *map_repair(map me,
 /*
  * Balances the AVL tree on insert.
  */
-static void map_insert_balance(map me, struct node *const item)
+static void map_insert_balance(map me, char *const item)
 {
-    struct node *grand_child = NULL;
-    struct node *child = item;
-    struct node *parent = item->parent;
+    char *grand_child = NULL;
+    char *child = item;
+    char *parent;
+    memcpy(&parent, item + node_parent_offset, ptr_size);
     while (parent) {
-        if (parent->left == child) {
-            parent->balance--;
+        char *parent_left;
+        memcpy(&parent_left, parent + node_left_child_offset, ptr_size);
+        if (parent_left == child) {
+            parent[0]--;
         } else {
-            parent->balance++;
+            parent[0]++;
         }
         /* If balance is zero after modification, then the tree is balanced. */
-        if (parent->balance == 0) {
+        if (parent[0] == 0) {
             return;
         }
         /* Must re-balance if not in {-1, 0, 1} */
-        if (parent->balance > 1 || parent->balance < -1) {
+        if (parent[0] > 1 || parent[0] < -1) {
             /* After one repair, the tree is balanced. */
             map_repair(me, parent, child, grand_child);
             return;
         }
         grand_child = child;
         child = parent;
-        parent = parent->parent;
+        memcpy(&parent, parent + node_parent_offset, ptr_size);
     }
 }
 
 /*
  * Creates and allocates a node.
  */
-static struct node *map_create_node(map me,
-                                    const void *const key,
-                                    const void *const value,
-                                    struct node *const parent)
+static char *map_create_node(map me, const void *const key,
+                             const void *const value, char *const parent)
 {
-    struct node *const insert = malloc(sizeof(struct node));
+    char *insert = malloc(1 + 3 * ptr_size + me->key_size + me->value_size);
     if (!insert) {
         return NULL;
     }
-    insert->parent = parent;
-    insert->balance = 0;
-    insert->key = malloc(me->key_size);
-    if (!insert->key) {
-        free(insert);
-        return NULL;
-    }
-    memcpy(insert->key, key, me->key_size);
-    insert->value = malloc(me->value_size);
-    if (!insert->value) {
-        free(insert->key);
-        free(insert);
-        return NULL;
-    }
-    memcpy(insert->value, value, me->value_size);
-    insert->left = NULL;
-    insert->right = NULL;
+    insert[0] = 0;
+    memcpy(insert + node_parent_offset, &parent, ptr_size);
+    memset(insert + node_left_child_offset, 0, ptr_size);
+    memset(insert + node_right_child_offset, 0, ptr_size);
+    memcpy(insert + node_key_offset, key, me->key_size);
+    memcpy(insert + node_key_offset + me->key_size, value, me->value_size);
     me->size++;
     return insert;
 }
@@ -335,9 +314,9 @@ static struct node *map_create_node(map me,
  */
 int map_put(map me, void *const key, void *const value)
 {
-    struct node *traverse;
+    char *traverse;
     if (!me->root) {
-        struct node *insert = map_create_node(me, key, value, NULL);
+        char *insert = map_create_node(me, key, value, NULL);
         if (!insert) {
             return -ENOMEM;
         }
@@ -346,33 +325,39 @@ int map_put(map me, void *const key, void *const value)
     }
     traverse = me->root;
     for (;;) {
-        const int compare = me->comparator(key, traverse->key);
+        const int compare = me->comparator(key, traverse + node_key_offset);
         if (compare < 0) {
-            if (traverse->left) {
-                traverse = traverse->left;
+            char *traverse_left;
+            memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+            if (traverse_left) {
+                traverse = traverse_left;
             } else {
-                struct node *insert = map_create_node(me, key, value, traverse);
+                char *insert = map_create_node(me, key, value, traverse);
                 if (!insert) {
                     return -ENOMEM;
                 }
-                traverse->left = insert;
+                memcpy(traverse + node_left_child_offset, &insert, ptr_size);
                 map_insert_balance(me, insert);
                 return 0;
             }
         } else if (compare > 0) {
-            if (traverse->right) {
-                traverse = traverse->right;
+            char *traverse_right;
+            memcpy(&traverse_right, traverse + node_right_child_offset,
+                   ptr_size);
+            if (traverse_right) {
+                traverse = traverse_right;
             } else {
-                struct node *insert = map_create_node(me, key, value, traverse);
+                char *insert = map_create_node(me, key, value, traverse);
                 if (!insert) {
                     return -ENOMEM;
                 }
-                traverse->right = insert;
+                memcpy(traverse + node_right_child_offset, &insert, ptr_size);
                 map_insert_balance(me, insert);
                 return 0;
             }
         } else {
-            memcpy(traverse->value, value, me->value_size);
+            memcpy(traverse + node_key_offset + me->key_size, value,
+                   me->value_size);
             return 0;
         }
     }
@@ -381,23 +366,28 @@ int map_put(map me, void *const key, void *const value)
 /*
  * If a match occurs, returns the match. Else, returns NULL.
  */
-static struct node *map_equal_match(map me, const void *const key)
+static char *map_equal_match(map me, const void *const key)
 {
-    struct node *traverse = me->root;
+    char *traverse = me->root;
     if (!traverse) {
         return NULL;
     }
     for (;;) {
-        const int compare = me->comparator(key, traverse->key);
+        const int compare = me->comparator(key, traverse + node_key_offset);
         if (compare < 0) {
-            if (traverse->left) {
-                traverse = traverse->left;
+            char *traverse_left;
+            memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+            if (traverse_left) {
+                traverse = traverse_left;
             } else {
                 return NULL;
             }
         } else if (compare > 0) {
-            if (traverse->right) {
-                traverse = traverse->right;
+            char *traverse_right;
+            memcpy(&traverse_right, traverse + node_right_child_offset,
+                   ptr_size);
+            if (traverse_right) {
+                traverse = traverse_right;
             } else {
                 return NULL;
             }
@@ -423,11 +413,11 @@ static struct node *map_equal_match(map me, const void *const key)
  */
 int map_get(void *const value, map me, void *const key)
 {
-    struct node *const traverse = map_equal_match(me, key);
+    char *const traverse = map_equal_match(me, key);
     if (!traverse) {
         return 0;
     }
-    memcpy(value, traverse->value, me->value_size);
+    memcpy(value, traverse + node_key_offset + me->key_size, me->value_size);
     return 1;
 }
 
@@ -451,45 +441,55 @@ int map_contains(map me, void *const key)
 /*
  * Repairs the AVL tree by pivoting on an item.
  */
-static struct node *map_repair_pivot(map me,
-                                     struct node *const item,
-                                     const int is_left_pivot)
+static char *map_repair_pivot(map me, char *const item, const int is_left_pivot)
 {
-    struct node *const child = is_left_pivot ? item->right : item->left;
-    struct node *const grand_child =
-            child->balance == 1 ? child->right : child->left;
+    char *child;
+    char *grand_child;
+    char *item_right;
+    char *item_left;
+    char *child_right;
+    char *child_left;
+    memcpy(&item_right, item + node_right_child_offset, ptr_size);
+    memcpy(&item_left, item + node_left_child_offset, ptr_size);
+    child = is_left_pivot ? item_right : item_left;
+    memcpy(&child_right, child + node_right_child_offset, ptr_size);
+    memcpy(&child_left, child + node_left_child_offset, ptr_size);
+    grand_child = child[0] == 1 ? child_right : child_left;
     return map_repair(me, item, child, grand_child);
 }
 
 /*
  * Goes back up the tree repairing it along the way.
  */
-static void map_trace_ancestors(map me, struct node *item)
+static void map_trace_ancestors(map me, char *item)
 {
-    struct node *child = item;
-    struct node *parent = item->parent;
+    char *child = item;
+    char *parent;
+    memcpy(&parent, item + node_parent_offset, ptr_size);
     while (parent) {
-        if (parent->left == child) {
-            parent->balance++;
+        char *parent_left;
+        memcpy(&parent_left, parent + node_left_child_offset, ptr_size);
+        if (parent_left == child) {
+            parent[0]++;
         } else {
-            parent->balance--;
+            parent[0]--;
         }
         /* The tree is balanced if balance is -1 or +1 after modification. */
-        if (parent->balance == -1 || parent->balance == 1) {
+        if (parent[0] == -1 || parent[0] == 1) {
             return;
         }
         /* Must re-balance if not in {-1, 0, 1} */
-        if (parent->balance > 1 || parent->balance < -1) {
-            child = map_repair_pivot(me, parent, parent->left == child);
-            parent = child->parent;
-            /* If balance is -1 or +1 after modification or the parent is */
-            /* NULL, then the tree is balanced. */
-            if (!parent || child->balance == -1 || child->balance == 1) {
+        if (parent[0] > 1 || parent[0] < -1) {
+            child = map_repair_pivot(me, parent, parent_left == child);
+            memcpy(&parent, child + node_parent_offset, ptr_size);
+            /* If balance is -1 or +1 after modification or   */
+            /* the parent is NULL, then the tree is balanced. */
+            if (!parent || child[0] == -1 || child[0] == 1) {
                 return;
             }
         } else {
             child = parent;
-            parent = parent->parent;
+            memcpy(&parent, parent + node_parent_offset, ptr_size);
         }
     }
 }
@@ -497,23 +497,23 @@ static void map_trace_ancestors(map me, struct node *item)
 /*
  * Balances the AVL tree on deletion.
  */
-static void map_delete_balance(map me,
-                               struct node *item,
-                               const int is_left_deleted)
+static void map_delete_balance(map me, char *item, const int is_left_deleted)
 {
     if (is_left_deleted) {
-        item->balance++;
+        item[0]++;
     } else {
-        item->balance--;
+        item[0]--;
     }
     /* If balance is -1 or +1 after modification, then the tree is balanced. */
-    if (item->balance == -1 || item->balance == 1) {
+    if (item[0] == -1 || item[0] == 1) {
         return;
     }
     /* Must re-balance if not in {-1, 0, 1} */
-    if (item->balance > 1 || item->balance < -1) {
+    if (item[0] > 1 || item[0] < -1) {
+        char *item_parent;
         item = map_repair_pivot(me, item, is_left_deleted);
-        if (!item->parent || item->balance == -1 || item->balance == 1) {
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        if (!item_parent || item[0] == -1 || item[0] == 1) {
             return;
         }
     }
@@ -523,101 +523,153 @@ static void map_delete_balance(map me,
 /*
  * Removes traverse when it has no children.
  */
-static void map_remove_no_children(map me, const struct node *const traverse)
+static void map_remove_no_children(map me, const char *const traverse)
 {
-    struct node *const parent = traverse->parent;
+    char *traverse_parent;
+    char *traverse_parent_left;
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
     /* If no parent and no children, then the only node is traverse. */
-    if (!parent) {
+    if (!traverse_parent) {
         me->root = NULL;
         return;
     }
+    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+           ptr_size);
     /* No re-reference needed since traverse has no children. */
-    if (parent->left == traverse) {
-        parent->left = NULL;
-        map_delete_balance(me, parent, 1);
+    if (traverse_parent_left == traverse) {
+        memset(traverse_parent + node_left_child_offset, 0, ptr_size);
+        map_delete_balance(me, traverse_parent, 1);
     } else {
-        parent->right = NULL;
-        map_delete_balance(me, parent, 0);
+        memset(traverse_parent + node_right_child_offset, 0, ptr_size);
+        map_delete_balance(me, traverse_parent, 0);
     }
 }
 
 /*
  * Removes traverse when it has one child.
  */
-static void map_remove_one_child(map me, const struct node *const traverse)
+static void map_remove_one_child(map me, const char *const traverse)
 {
-    struct node *const parent = traverse->parent;
+    char *traverse_parent;
+    char *traverse_left;
+    char *traverse_right;
+    char *traverse_parent_left;
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
+    memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
     /* If no parent, make the child of traverse the new root. */
-    if (!parent) {
-        if (traverse->left) {
-            traverse->left->parent = NULL;
-            me->root = traverse->left;
+    if (!traverse_parent) {
+        if (traverse_left) {
+            memset(traverse_left + node_parent_offset, 0, ptr_size);
+            me->root = traverse_left;
         } else {
-            traverse->right->parent = NULL;
-            me->root = traverse->right;
+            memset(traverse_right + node_parent_offset, 0, ptr_size);
+            me->root = traverse_right;
         }
         return;
     }
+    memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+           ptr_size);
     /* The parent of traverse now references the child of traverse. */
-    if (parent->left == traverse) {
-        if (traverse->left) {
-            parent->left = traverse->left;
-            traverse->left->parent = parent;
+    if (traverse_parent_left == traverse) {
+        if (traverse_left) {
+            memcpy(traverse_parent + node_left_child_offset, &traverse_left,
+                   ptr_size);
+            memcpy(traverse_left + node_parent_offset, &traverse_parent,
+                   ptr_size);
         } else {
-            parent->left = traverse->right;
-            traverse->right->parent = parent;
+            memcpy(traverse_parent + node_left_child_offset, &traverse_right,
+                   ptr_size);
+            memcpy(traverse_right + node_parent_offset, &traverse_parent,
+                   ptr_size);
         }
-        map_delete_balance(me, parent, 1);
+        map_delete_balance(me, traverse_parent, 1);
     } else {
-        if (traverse->left) {
-            parent->right = traverse->left;
-            traverse->left->parent = parent;
+        if (traverse_left) {
+            memcpy(traverse_parent + node_right_child_offset, &traverse_left,
+                   ptr_size);
+            memcpy(traverse_left + node_parent_offset, &traverse_parent,
+                   ptr_size);
         } else {
-            parent->right = traverse->right;
-            traverse->right->parent = parent;
+            memcpy(traverse_parent + node_right_child_offset, &traverse_right,
+                   ptr_size);
+            memcpy(traverse_right + node_parent_offset, &traverse_parent,
+                   ptr_size);
         }
-        map_delete_balance(me, parent, 0);
+        map_delete_balance(me, traverse_parent, 0);
     }
 }
 
 /*
  * Removes traverse when it has two children.
  */
-static void map_remove_two_children(map me, const struct node *const traverse)
+static void map_remove_two_children(map me, const char *const traverse)
 {
-    struct node *item;
-    struct node *parent;
-    const int is_left_deleted = traverse->right->left != NULL;
+    char *item;
+    char *item_parent;
+    char *parent;
+    char *traverse_parent;
+    char *traverse_right;
+    char *traverse_right_left;
+    int is_left_deleted;
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
+    memcpy(&traverse_right_left, traverse_right + node_left_child_offset,
+           ptr_size);
+    is_left_deleted = traverse_right_left != NULL;
     if (!is_left_deleted) {
-        item = traverse->right;
+        char *item_left;
+        memcpy(&item, traverse + node_right_child_offset, ptr_size);
         parent = item;
-        item->balance = traverse->balance;
-        item->parent = traverse->parent;
-        item->left = traverse->left;
-        item->left->parent = item;
+        item[0] = traverse[0];
+        memcpy(item + node_parent_offset, traverse + node_parent_offset,
+               ptr_size);
+        memcpy(item + node_left_child_offset, traverse + node_left_child_offset,
+               ptr_size);
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
+        memcpy(item_left + node_parent_offset, &item, ptr_size);
     } else {
-        item = traverse->right->left;
-        while (item->left) {
-            item = item->left;
+        char *item_left;
+        char *item_right;
+        item = traverse_right_left;
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
+        while (item_left) {
+            item = item_left;
+            memcpy(&item_left, item + node_left_child_offset, ptr_size);
         }
-        parent = item->parent;
-        item->balance = traverse->balance;
-        item->parent->left = item->right;
-        if (item->right) {
-            item->right->parent = item->parent;
+        memcpy(&parent, item + node_parent_offset, ptr_size);
+        item[0] = traverse[0];
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        memcpy(item_parent + node_left_child_offset,
+               item + node_right_child_offset, ptr_size);
+        memcpy(&item_right, item + node_right_child_offset, ptr_size);
+        if (item_right) {
+            memcpy(item_right + node_parent_offset, item + node_parent_offset,
+                   ptr_size);
         }
-        item->left = traverse->left;
-        item->left->parent = item;
-        item->right = traverse->right;
-        item->right->parent = item;
-        item->parent = traverse->parent;
+        memcpy(item + node_left_child_offset, traverse + node_left_child_offset,
+               ptr_size);
+        memcpy(&item_left, item + node_left_child_offset, ptr_size);
+        memcpy(item_left + node_parent_offset, &item, ptr_size);
+        memcpy(item + node_right_child_offset,
+               traverse + node_right_child_offset, ptr_size);
+        memcpy(&item_right, item + node_right_child_offset, ptr_size);
+        memcpy(item_right + node_parent_offset, &item, ptr_size);
+        memcpy(item + node_parent_offset, traverse + node_parent_offset,
+               ptr_size);
     }
-    if (!traverse->parent) {
+    memcpy(&traverse_parent, traverse + node_parent_offset, ptr_size);
+    if (!traverse_parent) {
         me->root = item;
-    } else if (traverse->parent->left == traverse) {
-        item->parent->left = item;
     } else {
-        item->parent->right = item;
+        char *traverse_parent_left;
+        memcpy(&traverse_parent_left, traverse_parent + node_left_child_offset,
+               ptr_size);
+        memcpy(&item_parent, item + node_parent_offset, ptr_size);
+        if (traverse_parent_left == traverse) {
+            memcpy(item_parent + node_left_child_offset, &item, ptr_size);
+        } else {
+            memcpy(item_parent + node_right_child_offset, &item, ptr_size);
+        }
     }
     map_delete_balance(me, parent, is_left_deleted);
 }
@@ -625,17 +677,19 @@ static void map_remove_two_children(map me, const struct node *const traverse)
 /*
  * Removes the element from the map.
  */
-static void map_remove_element(map me, struct node *const traverse)
+static void map_remove_element(map me, char *const traverse)
 {
-    if (!traverse->left && !traverse->right) {
+    char *traverse_left;
+    char *traverse_right;
+    memcpy(&traverse_left, traverse + node_left_child_offset, ptr_size);
+    memcpy(&traverse_right, traverse + node_right_child_offset, ptr_size);
+    if (!traverse_left && !traverse_right) {
         map_remove_no_children(me, traverse);
-    } else if (!traverse->left || !traverse->right) {
+    } else if (!traverse_left || !traverse_right) {
         map_remove_one_child(me, traverse);
     } else {
         map_remove_two_children(me, traverse);
     }
-    free(traverse->key);
-    free(traverse->value);
     free(traverse);
     me->size--;
 }
@@ -654,7 +708,7 @@ static void map_remove_element(map me, struct node *const traverse)
  */
 int map_remove(map me, void *const key)
 {
-    struct node *const traverse = map_equal_match(me, key);
+    char *const traverse = map_equal_match(me, key);
     if (!traverse) {
         return 0;
     }

--- a/tst/test_map.c
+++ b/tst/test_map.c
@@ -1,69 +1,80 @@
+#include <memory.h>
 #include "test.h"
 #include "../src/include/map.h"
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
 struct internal_map {
+    size_t size;
     size_t key_size;
     size_t value_size;
     int (*comparator)(const void *const one, const void *const two);
-    int size;
-    struct node *root;
+    char *root;
 };
 
 /*
- * Include this struct to verify the tree.
+ * Include this to verify the tree.
  */
-struct node {
-    struct node *parent;
-    int balance;
-    void *key;
-    void *value;
-    struct node *left;
-    struct node *right;
-};
-
+static const size_t ptr_size = sizeof(char *);
+/* Node balance is always the first byte (at index 0). */
+static const size_t node_parent_offset = sizeof(signed char);
+static const size_t node_left_child_offset = 1 + sizeof(char *);
+static const size_t node_right_child_offset = 1 + 2 * sizeof(char *);
+static const size_t node_key_offset = 1 + 3 * sizeof(char *);
+/* Assume the value starts right after the key ends. */
 
 /*
  * Verifies that the AVL tree rules are followed. The balance factor of an item
  * must be the right height minus the left height. Also, the left key must be
  * less than the right key.
  */
-static int map_verify_recursive(struct node *const item)
+static int map_verify_recursive(char *const item)
 {
     int left;
     int right;
     int max;
+    char *item_left;
+    char *item_right;
     if (!item) {
         return 0;
     }
-    left = map_verify_recursive(item->left);
-    right = map_verify_recursive(item->right);
+    memcpy(&item_left, item + node_left_child_offset, ptr_size);
+    memcpy(&item_right, item + node_right_child_offset, ptr_size);
+    left = map_verify_recursive(item_left);
+    right = map_verify_recursive(item_right);
     max = left > right ? left : right;
-    assert(right - left == item->balance);
-    if (item->left && item->right) {
-        const int left_val = *(int *) item->left->key;
-        const int right_val = *(int *) item->right->key;
+    assert(right - left == item[0]);
+    if (item_left && item_right) {
+        const int left_val = *(int *) (item_left + node_key_offset);
+        const int right_val = *(int *) (item_right + node_key_offset);
         assert(left_val < right_val);
     }
-    if (item->left) {
-        assert(item->left->parent == item);
-        assert(item->left->parent->key == item->key);
+    if (item_left) {
+        char *item_left_parent;
+        memcpy(&item_left_parent, item_left + node_parent_offset, ptr_size);
+        assert(item_left_parent == item);
+        assert(item_left_parent + node_key_offset == item + node_key_offset);
     }
-    if (item->right) {
-        assert(item->right->parent == item);
-        assert(item->right->parent->key == item->key);
+    if (item_right) {
+        char *item_right_parent;
+        memcpy(&item_right_parent, item_right + node_parent_offset, ptr_size);
+        assert(item_right_parent == item);
+        assert(item_right_parent + node_key_offset == item + node_key_offset);
     }
     return max + 1;
 }
 
-static int map_compute_size(struct node *const item)
+static size_t map_compute_size(char *const item)
 {
+    char *left;
+    char *right;
     if (!item) {
         return 0;
     }
-    return 1 + map_compute_size(item->left) + map_compute_size(item->right);
+    memcpy(&left, item + node_left_child_offset, ptr_size);
+    memcpy(&right, item + node_right_child_offset, ptr_size);
+    return 1 + map_compute_size(left) + map_compute_size(right);
 }
 
 static void map_verify(map me)
@@ -89,7 +100,7 @@ static void test_invalid_init(void)
 static void mutation_order(map me, const int *const arr, const int size)
 {
     int i;
-    int actual_size = 0;
+    size_t actual_size = 0;
     assert(map_is_empty(me));
     for (i = 0; i < size; i++) {
         int num = arr[i];
@@ -374,7 +385,7 @@ static void test_contains(void)
 
 static void test_stress_add(void)
 {
-    int count = 0;
+    size_t count = 0;
     int flip = 0;
     int i;
     map me = map_init(sizeof(int), sizeof(int), compare_int);
@@ -506,12 +517,6 @@ static void test_put_root_out_of_memory(map me)
     int key = 2;
     fail_malloc = 1;
     assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
-    assert(map_put(me, &key, &key) == -ENOMEM);
 }
 #endif
 
@@ -521,12 +526,6 @@ static void test_put_on_left_out_of_memory(map me)
     int key = 1;
     fail_malloc = 1;
     assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
-    assert(map_put(me, &key, &key) == -ENOMEM);
 }
 #endif
 
@@ -535,12 +534,6 @@ static void test_put_on_right_out_of_memory(map me)
 {
     int key = 3;
     fail_malloc = 1;
-    assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 1;
-    assert(map_put(me, &key, &key) == -ENOMEM);
-    fail_malloc = 1;
-    delay_fail_malloc = 2;
     assert(map_put(me, &key, &key) == -ENOMEM);
 }
 #endif


### PR DESCRIPTION
Using this function for testing:
```
    map me = map_init(sizeof(int), sizeof(double), compare_int);
    int count = 0;
    int i;
    for (i = 0; i < 1000000; i++) {
        double number = i + 0.5;
        map_put(me, &i, &number);
    }
    for (i = 0; i < 1000000; i++) {
        double get;
        map_get(&get, me, &i);
        assert(get < i + 0.6);
        assert(get > i + 0.4);
        count += map_contains(me, &i);
    }
    printf("%d\n", count);
    map_destroy(me);
```
The old version would take 0.97s and the new version takes 0.6s. This is an improvement of 40%.