### PR TITLE
Optimize deque block allocations

### DIFF
--- a/src/deque.c
+++ b/src/deque.c
@@ -85,7 +85,7 @@ deque deque_init(const size_t data_size)
         free(init);
         return NULL;
     }
-    init->data[init->start_index / init->block_size] = block;
+    init->data[init->alloc_block_start] = block;
     return init;
 }
 
@@ -611,7 +611,7 @@ bk_err deque_clear(deque me)
     me->alloc_block_start = me->start_index / me->block_size;
     me->alloc_block_end = me->alloc_block_start;
     me->data = updated_data;
-    me->data[me->start_index / me->block_size] = updated_block;
+    me->data[me->alloc_block_start] = updated_block;
     return BK_OK;
 }
 

--- a/src/deque.c
+++ b/src/deque.c
@@ -318,9 +318,16 @@ bk_err deque_push_front(deque me, void *const data)
     if (me->start_index % me->block_size == 0) {
         const size_t add_block_index = me->start_index / me->block_size - 1;
         if (add_block_index < me->alloc_block_start) {
-            me->data[add_block_index] = malloc(me->block_size * me->data_size);
-            if (!me->data[add_block_index]) {
-                return -BK_ENOMEM;
+            const size_t end_block = (me->end_index - 1) / me->block_size;
+            if (end_block < me->alloc_block_end) {
+                me->data[add_block_index] = me->data[me->alloc_block_end];
+                me->alloc_block_end--;
+            } else {
+                me->data[add_block_index] =
+                        malloc(me->block_size * me->data_size);
+                if (!me->data[add_block_index]) {
+                    return -BK_ENOMEM;
+                }
             }
             me->alloc_block_start--;
         }
@@ -368,9 +375,16 @@ bk_err deque_push_back(deque me, void *const data)
     if (me->end_index % me->block_size == 0) {
         const size_t add_block_index = me->end_index / me->block_size;
         if (add_block_index > me->alloc_block_end) {
-            me->data[add_block_index] = malloc(me->block_size * me->data_size);
-            if (!me->data[add_block_index]) {
-                return -BK_ENOMEM;
+            const size_t start_block = me->start_index / me->block_size;
+            if (start_block > me->alloc_block_start) {
+                me->data[add_block_index] = me->data[me->alloc_block_start];
+                me->alloc_block_start++;
+            } else {
+                me->data[add_block_index] =
+                        malloc(me->block_size * me->data_size);
+                if (!me->data[add_block_index]) {
+                    return -BK_ENOMEM;
+                }
             }
             me->alloc_block_end++;
         }

--- a/src/deque.c
+++ b/src/deque.c
@@ -34,6 +34,8 @@ struct internal_deque {
     size_t start_index;
     size_t end_index;
     size_t block_count;
+    size_t alloc_block_start;
+    size_t alloc_block_end;
     char **data;
 };
 
@@ -70,6 +72,8 @@ deque deque_init(const size_t data_size)
             init->block_size * BKTHOMPS_DEQUE_INITIAL_BLOCK_COUNT / 2;
     init->end_index = init->start_index;
     init->block_count = BKTHOMPS_DEQUE_INITIAL_BLOCK_COUNT;
+    init->alloc_block_start = init->start_index / init->block_size;
+    init->alloc_block_end = init->alloc_block_start;
     init->data = calloc(init->block_count, sizeof(char *));
     if (!init->data) {
         free(init);
@@ -585,14 +589,14 @@ bk_err deque_clear(deque me)
         return -BK_ENOMEM;
     }
     for (i = 0; i < me->block_count; i++) {
-        char *block;
-        memcpy(&block, me->data + i, sizeof(char *));
-        free(block);
+        free(me->data[i]);
     }
     free(me->data);
     me->start_index = me->block_size * BKTHOMPS_DEQUE_INITIAL_BLOCK_COUNT / 2;
     me->end_index = me->start_index;
     me->block_count = BKTHOMPS_DEQUE_INITIAL_BLOCK_COUNT;
+    me->alloc_block_start = me->start_index / me->block_size;
+    me->alloc_block_end = me->alloc_block_start;
     me->data = updated_data;
     me->data[me->start_index / me->block_size] = updated_block;
     return BK_OK;

--- a/src/deque.c
+++ b/src/deque.c
@@ -239,10 +239,7 @@ bk_err deque_add_all(deque me, void *const arr, const size_t size)
         me->data = temp;
         me->block_count = new_block_count;
     }
-    for (i = block_index + 1; i <= block_index + needed_blocks; i++) {
-        if (i <= me->alloc_block_end) {
-            continue;
-        }
+    for (i = me->alloc_block_end + 1; i <= block_index + needed_blocks; i++) {
         me->data[i] = malloc(me->block_size * me->data_size);
         if (!me->data[i]) {
             return -BK_ENOMEM;

--- a/tst/test_deque.c
+++ b/tst/test_deque.c
@@ -463,7 +463,7 @@ static void test_big_object(void)
     assert(!deque_destroy(me));
 }
 
-void test_add_all(int big_arr_size)
+static void test_add_all(int big_arr_size)
 {
     int i;
     double small_array[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
@@ -491,7 +491,7 @@ void test_add_all(int big_arr_size)
     free(big_array);
 }
 
-void test_add_all_failure(void)
+static void test_add_all_failure(void)
 {
     const size_t big_arr_size = 2000;
     size_t i;
@@ -531,44 +531,78 @@ void test_add_all_failure(void)
     free(big_array);
 }
 
-void test_block_reuse_forwards(void)
+static void test_block_reuse_forwards(void)
 {
     size_t i;
     size_t queue_size = 1500;
     deque queue = deque_init(sizeof(double));
     for (i = 0; i < queue_size; i++) {
         double d = i;
-        deque_push_back(queue, &d);
+        assert(deque_push_back(queue, &d) == BK_OK);
     }
     for (i = 0; i < queue_size; i++) {
         double d = i;
         double get;
-        deque_push_back(queue, &d);
-        deque_pop_front(&get, queue);
+        assert(deque_push_back(queue, &d) == BK_OK);
+        assert(deque_pop_front(&get, queue) == BK_OK);
         assert(get == d);
     }
-    assert(deque_trim(queue) == BK_OK);
     deque_destroy(queue);
 }
 
-void test_block_reuse_backwards(void)
+static void test_block_reuse_backwards(void)
 {
     size_t i;
     size_t queue_size = 1500;
     deque queue = deque_init(sizeof(double));
     for (i = 0; i < queue_size; i++) {
         double d = i;
-        deque_push_front(queue, &d);
+        assert(deque_push_front(queue, &d) == BK_OK);
     }
     for (i = 0; i < queue_size; i++) {
         double d = i;
         double get;
-        deque_push_front(queue, &d);
-        deque_pop_back(&get, queue);
+        assert(deque_push_front(queue, &d) == BK_OK);
+        assert(deque_pop_back(&get, queue) == BK_OK);
         assert(get == d);
     }
-    assert(deque_trim(queue) == BK_OK);
     deque_destroy(queue);
+}
+
+static void test_trim_both_sides(void)
+{
+    int i;
+    deque me = deque_init(sizeof(int));
+    for (i = 999; i >= 0; i--) {
+        assert(deque_push_front(me, &i) == BK_OK);
+        assert(deque_push_back(me, &i) == BK_OK);
+    }
+    assert(deque_size(me) == 2000);
+    assert(deque_trim(me) == BK_OK);
+    assert(deque_size(me) == 2000);
+    for (i = 0; i < 500; i++) {
+        int get = 0xfacade;
+        assert(deque_pop_front(&get, me) == BK_OK);
+        assert(get == i);
+        get = 0xfacade;
+        assert(deque_pop_back(&get, me) == BK_OK);
+        assert(get == i);
+    }
+    assert(deque_size(me) == 1000);
+    assert(deque_trim(me) == BK_OK);
+    assert(deque_size(me) == 1000);
+    for (i = 500; i < 1000; i++) {
+        int get = 0xfacade;
+        assert(deque_pop_front(&get, me) == BK_OK);
+        assert(get == i);
+        get = 0xfacade;
+        assert(deque_pop_back(&get, me) == BK_OK);
+        assert(get == i);
+    }
+    assert(deque_size(me) == 0);
+    assert(deque_trim(me) == BK_OK);
+    assert(deque_size(me) == 0);
+    deque_destroy(me);
 }
 
 void test_deque(void)
@@ -599,4 +633,5 @@ void test_deque(void)
     test_add_all_failure();
     test_block_reuse_forwards();
     test_block_reuse_backwards();
+    test_trim_both_sides();
 }

--- a/tst/test_deque.c
+++ b/tst/test_deque.c
@@ -531,6 +531,44 @@ void test_add_all_failure(void)
     free(big_array);
 }
 
+void test_block_reuse_forwards(void)
+{
+    size_t i;
+    size_t queue_size = 1500;
+    deque queue = deque_init(sizeof(double));
+    for (i = 0; i < queue_size; i++) {
+        double d = i;
+        deque_push_back(queue, &d);
+    }
+    for (i = 0; i < queue_size; i++) {
+        double d = i;
+        double get;
+        deque_push_back(queue, &d);
+        deque_pop_front(&get, queue);
+        assert(get == d);
+    }
+    deque_destroy(queue);
+}
+
+void test_block_reuse_backwards(void)
+{
+    size_t i;
+    size_t queue_size = 1500;
+    deque queue = deque_init(sizeof(double));
+    for (i = 0; i < queue_size; i++) {
+        double d = i;
+        deque_push_front(queue, &d);
+    }
+    for (i = 0; i < queue_size; i++) {
+        double d = i;
+        double get;
+        deque_push_front(queue, &d);
+        deque_pop_back(&get, queue);
+        assert(get == d);
+    }
+    deque_destroy(queue);
+}
+
 void test_deque(void)
 {
     int i;
@@ -557,4 +595,6 @@ void test_deque(void)
         test_add_all(i);
     }
     test_add_all_failure();
+    test_block_reuse_forwards();
+    test_block_reuse_backwards();
 }

--- a/tst/test_deque.c
+++ b/tst/test_deque.c
@@ -547,6 +547,7 @@ void test_block_reuse_forwards(void)
         deque_pop_front(&get, queue);
         assert(get == d);
     }
+    assert(deque_trim(queue) == BK_OK);
     deque_destroy(queue);
 }
 
@@ -566,6 +567,7 @@ void test_block_reuse_backwards(void)
         deque_pop_back(&get, queue);
         assert(get == d);
     }
+    assert(deque_trim(queue) == BK_OK);
     deque_destroy(queue);
 }
 

--- a/tst/test_deque.c
+++ b/tst/test_deque.c
@@ -268,12 +268,13 @@ static void test_large_elements(void)
 #if STUB_MALLOC
 static void test_init_out_of_memory(void)
 {
-    fail_calloc = 1;
-    assert(!deque_init(sizeof(int)));
     fail_malloc = 1;
     assert(!deque_init(sizeof(int)));
     fail_malloc = 1;
     delay_fail_malloc = 1;
+    assert(!deque_init(sizeof(int)));
+    fail_malloc = 1;
+    delay_fail_malloc = 2;
     assert(!deque_init(sizeof(int)));
 }
 #endif
@@ -342,7 +343,7 @@ static void test_clear_out_of_memory(void)
         deque_push_back(me, &i);
     }
     assert(deque_size(me) == 32);
-    fail_calloc = 1;
+    fail_malloc = 1;
     assert(deque_clear(me) == -ENOMEM);
     for (i = 0; i < 32; i++) {
         int get = 0xfacade;
@@ -351,6 +352,7 @@ static void test_clear_out_of_memory(void)
     }
     assert(deque_size(me) == 32);
     fail_malloc = 1;
+    delay_fail_malloc = 1;
     assert(deque_clear(me) == -ENOMEM);
     for (i = 0; i < 32; i++) {
         int get = 0xfacade;


### PR DESCRIPTION
Rather than allocating a new block every time it is needed, it will check the other end of the outer array to see if blocks are available but not in use. This way, if a deque is being used like a queue, the block count will not arbitrarily grow.